### PR TITLE
41 bundle ressource missing for not exported dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ example/iosApp/spm
 plugin-build/plugin/src/functionalTest/resources/LocalSourceDummyFramework/.build
 example/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
 example/exportedNativeShared/.swiftpm/xcode/xcuserdata
+example/exportedNativeIosShared/.swiftpm/xcode/xcuserdata

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ For more information, refer to the [SwiftDependency](https://github.com/frankois
 
 ### 3. Add your embedded Swift code
 
-You can now add your embedded Swift code in the `src/swift/[cinteropname]` folder.
+You can now add your embedded Swift code in the `src/swift/[cinteropname]` folder; it will be your bridge between Swift and Kotlin.
 
-> [!IMPORTANT]
+> [!TIP]
 > Your swift code need to be mark as [@objc/@objcMembers](https://akdebuging.com/posts/what-is-objc-and-objcmember/) and the visibility set as `public`
 > or it won't be exported and available from your Kotlin code
 > ```swift
@@ -140,7 +140,25 @@ You can now add your embedded Swift code in the `src/swift/[cinteropname]` folde
 > }
 > ```
 
-### 3.1. With external dependencies
+### 4. Add external dependencies
+
+The Plug-in is reproducing the CocoaPods plugin behavior with the same kind of issues about third-party dependency but less intrusively.
+
+> [!IMPORTANT]
+>
+> A local swift package is being generated during the build and this message diplayed
+> ```
+> Spm4Kmp: A local Swift package has been generated at
+> /path/to/the/local/package
+> Please add it to your xcode project as a local package dependency.
+> ```
+> Add the folder to your project as a Local package, that's all.
+>
+> Note : When updating your configuration, reset the package cache to apply the modification.
+> 
+
+
+### 4.1. Using inside your bridge
 
 You can also use the dependency you have added in the `swiftPackageConfig` block in your Swift code.
 
@@ -174,12 +192,9 @@ import CryptoSwift
 }
 ```
 
-### 3.2. Export your dependency directly to your Kotlin Code
+### 4.2. Using inside your Kotlin
 
-You can also use the dependency you have added in the `swiftPackageConfig` in your Kotlin and Swift applications.
-
-> [!WARNING]
-> This feature is highly experimental
+You can also use the dependency you have added in the `swiftPackageConfig` in your Kotlin applications.
 
 ```kotlin
 swiftPackageConfig {
@@ -196,18 +211,8 @@ swiftPackageConfig {
 }
 ```
 
-> [!IMPORTANT]
-> When exporting dependency, some configuration need to be added to your xcode project.
->
-> A local swift package is being generated during the build and this message diplayed
-> ```
-> Spm4Kmp: A local Swift package has been generated in /path/to/the/local/package
-> Please add it to your project as a local package dependency.
-> ```
-> Add the folder to your project as a Local package, that's all.
 
-
-### 4. Configuration by target
+### 5. Configuration by target
 
 You can set a different configuration for each each target you manage.
 

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -84,7 +84,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
-val testRessources = "${layout.projectDirectory.asFile.path}/../plugin-build/plugin/src/functionalTest/resources"
+val testResources = "${layout.projectDirectory.asFile.path}/../plugin-build/plugin/src/functionalTest/resources"
 swiftPackageConfig {
     create("nativeIosShared") {
         // optional parameters
@@ -117,12 +117,12 @@ swiftPackageConfig {
                 version = "11.6.0",
             ),
             SwiftDependency.Binary.Local(
-                path = "$testRessources/DummyFramework.xcframework.zip",
+                path = "$testResources/DummyFramework.xcframework.zip",
                 packageName = "DummyFramework",
                 exportToKotlin = true,
             ),
             SwiftDependency.Package.Local(
-                path = "$testRessources/LocalSourceDummyFramework",
+                path = "$testResources/LocalSourceDummyFramework",
                 packageName = "LocalSourceDummyFramework",
                 products = {
                     // Export to Kotlin for use in shared Kotlin code, false by default
@@ -143,7 +143,7 @@ swiftPackageConfig {
     create("nativeMacosShared") {
         dependency(
             SwiftDependency.Package.Local(
-                path = "$testRessources/LocalSourceDummyFramework",
+                path = "$testResources/LocalSourceDummyFramework",
                 packageName = "LocalSourceDummyFramework",
                 products = {
                     // Export to Kotlin for use in shared Kotlin code, false by default

--- a/example/exportedNativeIosShared/Package.swift
+++ b/example/exportedNativeIosShared/Package.swift
@@ -15,15 +15,17 @@ let package = Package(
     .package(
       path:
         "/Users/francoisdabonot/DEV/spm-kmp-plugin/example/../plugin-build/plugin/src/functionalTest/resources/LocalSourceDummyFramework"
-    ),
+    ), .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.1"),
   ],
   targets: [
     .target(
       name: "exportedNativeIosShared",
       dependencies: [
         .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
-        .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"), "DummyFramework",
+        .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"),
+        .product(name: "FirebaseDatabase", package: "firebase-ios-sdk"), "DummyFramework",
         .product(name: "LocalSourceDummyFramework", package: "LocalSourceDummyFramework"),
+        .product(name: "CryptoSwift", package: "CryptoSwift"),
       ],
       path: "Sources"),
     .binaryTarget(

--- a/example/exportedNativeMacosShared/Package.swift
+++ b/example/exportedNativeMacosShared/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+  name: "exportedNativeMacosShared",
+  platforms: [.iOS("12.0"), .macOS("10.13"), .tvOS("12.0"), .watchOS("4.0")],
+  products: [
+    .library(
+      name: "exportedNativeMacosShared",
+      type: .static,
+      targets: ["exportedNativeMacosShared"])
+  ],
+  dependencies: [
+    .package(
+      path:
+        "/Users/francoisdabonot/DEV/spm-kmp-plugin/example/../plugin-build/plugin/src/functionalTest/resources/LocalSourceDummyFramework"
+    )
+  ],
+  targets: [
+    .target(
+      name: "exportedNativeMacosShared",
+      dependencies: [
+        .product(name: "LocalSourceDummyFramework", package: "LocalSourceDummyFramework")
+      ],
+      path: "Sources")
+
+  ]
+)

--- a/example/exportedNativeMacosShared/Sources/DummySPMFile.swift
+++ b/example/exportedNativeMacosShared/Sources/DummySPMFile.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/SpmForKmpPlugin.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/SpmForKmpPlugin.kt
@@ -5,7 +5,6 @@ package io.github.frankois944.spmForKmp
 import io.github.frankois944.spmForKmp.config.getAndCreateFakeDefinitionFile
 import io.github.frankois944.spmForKmp.definition.PackageRootDefinitionExtension
 import io.github.frankois944.spmForKmp.definition.SwiftDependency
-import io.github.frankois944.spmForKmp.definition.helpers.filterExportableDependency
 import io.github.frankois944.spmForKmp.tasks.CompileSwiftPackageTask
 import io.github.frankois944.spmForKmp.tasks.GenerateCInteropDefinitionTask
 import io.github.frankois944.spmForKmp.tasks.GenerateExportableManifestTask
@@ -92,7 +91,6 @@ public abstract class SpmForKmpPlugin : Plugin<Project> {
                             )
                         }
 
-                    val exportableDependencies = extension.packageDependencies.filterExportableDependency()
                     val extensionNameCapitalized = extension.name.capitalized()
                     val exportedManifestDirectory =
                         layout.projectDirectory
@@ -100,14 +98,14 @@ public abstract class SpmForKmpPlugin : Plugin<Project> {
                             .resolve("exported$extensionNameCapitalized")
 
                     val exportedManifestTask: TaskProvider<GenerateExportableManifestTask>? =
-                        if (exportableDependencies.isNotEmpty()) {
+                        if (extension.packageDependencies.isNotEmpty()) {
                             tasks.register(
                                 getTaskName(TASK_GENERATE_EXPORTABLE_PACKAGE, extension.name),
                                 GenerateExportableManifestTask::class.java,
                             ) { taskConfig ->
                                 configureExportableManifestTask(
                                     taskConfig,
-                                    exportableDependencies,
+                                    extension.packageDependencies,
                                     extension,
                                     exportedManifestDirectory.name,
                                     exportedManifestDirectory,
@@ -307,8 +305,6 @@ public abstract class SpmForKmpPlugin : Plugin<Project> {
         taskConfig.toolsVersion.set(extension.toolsVersion)
         manifestDir.mkdirs()
         taskConfig.manifestFile.set(manifestDir.resolve(SWIFT_PACKAGE_NAME))
-        logger.warn("Spm4Kmp: A local Swift package has been generated in $manifestDir")
-        logger.warn("Please add it to your xcode project as a local package dependency.")
     }
 
     @Suppress("LongParameterList")

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/GenerateExportableManifestTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/GenerateExportableManifestTask.kt
@@ -55,8 +55,9 @@ internal abstract class GenerateExportableManifestTask : DefaultTask() {
                 .asFile
                 .parentFile
                 .resolve("Sources")
-                .also { it.mkdirs() }
-        sourceDir.resolve("DummySPMFile.swift").writeText("import Foundation")
+                .takeIf { !it.exists() }
+                ?.also { it.mkdirs() }
+        sourceDir?.resolve("DummySPMFile.swift")?.writeText("import Foundation")
     }
 
     @TaskAction
@@ -82,6 +83,13 @@ internal abstract class GenerateExportableManifestTask : DefaultTask() {
             project.swiftFormat(
                 manifestFile.asFile.get(),
             )
+            logger.warn("Spm4Kmp: A local Swift package has been generated at")
+            logger.warn(
+                manifestFile
+                    .get()
+                    .asFile.parentFile.path,
+            )
+            logger.warn("Please add it to your xcode project as a local package dependency.")
         } catch (ex: Exception) {
             logger.error(
                 """


### PR DESCRIPTION
Updating the behavior :

- Now

When at least one dependency is added to the configuration, a local package is generated.
The user must add this local package to his xcode project.

- Before

The local package was generated when at least one dependency was exported, but it was missing a lot of things when integrated into Xcode.