### PR TITLE
Ignore SPM error

### DIFF
--- a/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/ErrorPackageTest.kt
+++ b/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/ErrorPackageTest.kt
@@ -1,0 +1,50 @@
+package io.github.frankois944.spmForKmp
+
+import com.autonomousapps.kit.GradleBuilder
+import com.autonomousapps.kit.truth.TestKitTruth.Companion.assertThat
+import io.github.frankois944.spmForKmp.definition.SwiftDependency
+import io.github.frankois944.spmForKmp.fixture.SmpKMPTestFixture
+import io.github.frankois944.spmForKmp.fixture.SwiftSource
+import io.github.frankois944.spmForKmp.utils.BaseTest
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class ErrorPackageTest : BaseTest() {
+    @Test
+    fun `build with an swift package error`() {
+        // Given
+        val fixture =
+            SmpKMPTestFixture
+                .builder()
+                .withBuildPath(testProjectDir.root.absolutePath)
+                .withMinIos("15.0")
+                .withDependencies(
+                    buildList {
+                        add(
+                            SwiftDependency.Package.Remote.Version(
+                                url = URI("https://github.com/googlemaps/ios-maps-sdk.git"),
+                                version = "9.3.0",
+                                products = {
+                                    add("GoogleMaps")
+                                },
+                            ),
+                        )
+                    },
+                ).withSwiftSources(
+                    SwiftSource.of(
+                        content =
+                            """
+                            import GoogleMaps
+                            """.trimIndent(),
+                    ),
+                ).build()
+
+        val result =
+            GradleBuilder
+                .runner(fixture.gradleProject.rootDir, "build")
+                .build()
+
+        // Then
+        assertThat(result).task(":library:build").succeeded()
+    }
+}

--- a/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/fixture/SmpKMPTestFixture.kt
+++ b/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/fixture/SmpKMPTestFixture.kt
@@ -388,6 +388,16 @@ swiftPackageConfig {
                 config = config.copy(sharedSecurityPath = path)
             }
 
+        fun withMacos(minMacos: String) =
+            apply {
+                config = config.copy(minMacos = minMacos)
+            }
+
+        fun withMinIos(minIos: String) =
+            apply {
+                config = config.copy(minIos = minIos)
+            }
+
         fun withRawDependencies(vararg sources: KotlinSource) =
             apply {
                 config = config.copy(rawDependencyConfiguration = sources.toList())

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/operations/XcodeOperations.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/operations/XcodeOperations.kt
@@ -244,9 +244,11 @@ OUTPUT $standardOutput
 ###
             """.trimMargin(),
         )
-        throw RuntimeException(
-            "RUN CMD $action failed",
-        )
+        if (!errorOutput.toString().contains("unexpected binary framework")) {
+            throw RuntimeException(
+                "RUN CMD $action failed",
+            )
+        }
     } else {
         logger.debug(
             """


### PR DESCRIPTION
don't consider as a failure if the message "unexpected binary framework" is printed

#62 