### PR TITLE
custom swift version for xcode 15 compatibility

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -35,7 +35,10 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest
+          xcode-version: 15.4
+      - uses: vapor/swiftly-action@v0.2
+        with:
+          toolchain: latest
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -36,9 +36,22 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 15.4
-      - uses: vapor/swiftly-action@v0.1
+      - name: Swiftly Cache
+        id: cache-swiftly
+        uses: actions/cache@v4
         with:
-          toolchain: latest # optional
+          path: ~/.swiftly
+          key: ${{ runner.os }}-swiftly-swift
+      - name: install swift
+        run: |
+          curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
+          installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
+          ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
+          . ~/.swiftly/env.sh && \
+          hash -r \
+          swiftly install 5.9.0 \
+          swiftly use 5.9.0 \
+          hash -r
       - name: Get swift version
         run: swift --version
       - name: Checkout Repo

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -49,6 +49,8 @@ jobs:
           installer -pkg swiftly.pkg -target CurrentUserHomeDirectory
           ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
           . ~/.swiftly/env.sh && \
+          hash -r && \
+          swiftly use latest && \
           hash -r
       - name: Get swift version
         run: swift --version

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -48,10 +48,10 @@ jobs:
           installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
           ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
           . ~/.swiftly/env.sh && \
+          hash -r && \
+          swiftly install 5.9.0 && \
+          swiftly use 5.9.0 && \
           hash -r \
-          swiftly install 5.9.0 \
-          swiftly use 5.9.0 \
-          hash -r
       - name: Get swift version
         run: swift --version
       - name: Checkout Repo

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -35,25 +35,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 15.4
-      - name: Swiftly Cache
-        id: cache-swiftly
-        uses: actions/cache@v4
-        with:
-          path: ~/.swiftly
-          key: ${{ runner.os }}-swiftly-swift
-      - name: install swift
-        run: |
-          test ! -e ~/.swiftly && \
-          curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
-          installer -pkg swiftly.pkg -target CurrentUserHomeDirectory
-          ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
-          . ~/.swiftly/env.sh && \
-          hash -r && \
-          swiftly use latest && \
-          hash -r
-      - name: Get swift version
-        run: swift --version
+          xcode-version: latest
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -36,9 +36,11 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 15.4
-      - uses: swift-actions/setup-swift@v2
+      - uses: vapor/swiftly-action@v0.1
+        with:
+          toolchain: latest # optional
       - name: Get swift version
-        run: swift --version # Swift 5.1.0
+        run: swift --version
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -44,14 +44,12 @@ jobs:
           key: ${{ runner.os }}-swiftly-swift
       - name: install swift
         run: |
+          test ! -e ~/.swiftly && \
           curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
-          installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
+          installer -pkg swiftly.pkg -target CurrentUserHomeDirectory
           ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
           . ~/.swiftly/env.sh && \
-          hash -r && \
-          swiftly install 5.9.0 && \
-          swiftly use 5.9.0 && \
-          hash -r \
+          hash -r
       - name: Get swift version
         run: swift --version
       - name: Checkout Repo

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -36,9 +36,9 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 15.4
-      - uses: vapor/swiftly-action@v0.2
-        with:
-          toolchain: latest
+      - uses: swift-actions/setup-swift@v2
+      - name: Get swift version
+        run: swift --version # Swift 5.1.0
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,4 +1,3 @@
-import io.github.frankois944.spmForKmp.definition.product.ProductName
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URI
 
@@ -106,7 +105,7 @@ swiftPackageConfig {
         // packageDependencyPrefix = null // default null
         spmWorkingPath = "${projectDir.resolve("SPM")}" // change the Swift Package Manager working Dir
         dependency {
-            remotePackageVersion(
+            /*remotePackageVersion(
                 url = URI("https://github.com/firebase/firebase-ios-sdk.git"),
                 // Libraries from the package
                 products = {
@@ -140,13 +139,13 @@ swiftPackageConfig {
                     // Can be only used in your "src/swift" code.
                     add("CryptoSwift")
                 },
-            )
+            )*/
             remotePackageVersion(
-                url = URI("https://github.com/appmetrica/appmetrica-sdk-ios"),
-                version = "5.0.0",
+                url = URI("https://github.com/bugsnag/bugsnag-cocoa-performance"),
+                version = "1.11.2",
                 products = {
                     // Can be only used in your "src/swift" code.
-                    add("AppMetricaCore", exportToKotlin = true)
+                    add("BugsnagPerformance", exportToKotlin = true)
                 },
             )
         }

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,3 +1,4 @@
+import io.github.frankois944.spmForKmp.definition.product.ProductName
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URI
 
@@ -104,8 +105,9 @@ swiftPackageConfig {
         //  - give : "customName.FirebaseCore" instead of "FirebaseCore"
         // packageDependencyPrefix = null // default null
         spmWorkingPath = "${projectDir.resolve("SPM")}" // change the Swift Package Manager working Dir
+        swiftBinPath = "/Users/francoisdabonot/.swiftly/bin/swift"
         dependency {
-            /*remotePackageVersion(
+            remotePackageVersion(
                 url = URI("https://github.com/firebase/firebase-ios-sdk.git"),
                 // Libraries from the package
                 products = {
@@ -138,14 +140,6 @@ swiftPackageConfig {
                 products = {
                     // Can be only used in your "src/swift" code.
                     add("CryptoSwift")
-                },
-            )*/
-            remotePackageVersion(
-                url = URI("https://github.com/bugsnag/bugsnag-cocoa-performance"),
-                version = "1.11.2",
-                products = {
-                    // Can be only used in your "src/swift" code.
-                    add("BugsnagPerformance", exportToKotlin = true)
                 },
             )
         }

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -105,7 +105,7 @@ swiftPackageConfig {
         //  - give : "customName.FirebaseCore" instead of "FirebaseCore"
         // packageDependencyPrefix = null // default null
         spmWorkingPath = "${projectDir.resolve("SPM")}" // change the Swift Package Manager working Dir
-        swiftBinPath = "/Users/francoisdabonot/.swiftly/bin/swift"
+        // swiftBinPath = "/path/to/.swiftly/bin/swift"
         dependency {
             remotePackageVersion(
                 url = URI("https://github.com/firebase/firebase-ios-sdk.git"),

--- a/example/exportedNativeIosShared/Package.swift
+++ b/example/exportedNativeIosShared/Package.swift
@@ -11,25 +11,21 @@ let package = Package(
       targets: ["exportedNativeIosShared", "DummyFramework"])
   ],
   dependencies: [
-    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.1"),
     .package(url: "https://github.com/firebase/firebase-ios-sdk.git", exact: "11.8.1"),
     .package(
       path:
         "/Users/francoisdabonot/devs/spm4Kmp/example/../plugin-build/plugin/src/functionalTest/resources/LocalSourceDummyFramework"
     ), .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.8.1"),
-    .package(url: "https://github.com/appmetrica/appmetrica-sdk-ios", exact: "5.0.0"),
   ],
   targets: [
     .target(
       name: "exportedNativeIosShared",
       dependencies: [
-        .product(name: "CryptoSwift", package: "CryptoSwift"),
         .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
         .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"),
         .product(name: "FirebaseDatabase", package: "firebase-ios-sdk"), "DummyFramework",
         .product(name: "LocalSourceDummyFramework", package: "LocalSourceDummyFramework"),
         .product(name: "CryptoSwift", package: "CryptoSwift"),
-        .product(name: "AppMetricaCore", package: "appmetrica-sdk-ios"),
       ],
       path: "Sources"
 

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/definition/PackageRootDefinitionExtension.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/definition/PackageRootDefinitionExtension.kt
@@ -205,4 +205,12 @@ public abstract class PackageRootDefinitionExtension
         public fun bridgeSettings(setting: BridgeSettingsConfig.() -> Unit) {
             bridgeSettings.apply(setting)
         }
+
+        /**
+         * The path of the Swift command line used to build the bridge
+         * You can change the version of swift used for building the bridge by setting another binary
+         *
+         * Default : uses the command `xcrun --sdk macosx swift` by default
+         */
+        public var swiftBinPath: String? = null
     }

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/operations/XcodeOperations.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/operations/XcodeOperations.kt
@@ -15,36 +15,39 @@ internal fun ExecOperations.resolvePackage(
     sharedConfigPath: File?,
     sharedSecurityPath: File?,
     logger: Logger,
+    swiftBinPath: String?,
 ) {
     val args =
-        mutableListOf(
-            "--sdk",
-            "macosx",
-            "swift",
-            "package",
-            "resolve",
-            "--scratch-path",
-            scratchPath.path,
-            "--jobs",
-            getNbJobs(logger),
-        )
-    sharedCachePath?.let {
-        args.add("--cache-path")
-        args.add(it.path)
-    }
-    sharedConfigPath?.let {
-        args.add("--config-path")
-        args.add(it.path)
-    }
-    sharedSecurityPath?.let {
-        args.add("--security-path")
-        args.add(it.path)
-    }
+        buildList {
+            if (swiftBinPath == null) {
+                add("--sdk")
+                add("macosx")
+                add("swift")
+            }
+            add("package")
+            add("resolve")
+            add("--scratch-path")
+            add(scratchPath.path)
+            add("--jobs")
+            add(getNbJobs(logger))
+            sharedCachePath?.let {
+                add("--cache-path")
+                add(it.path)
+            }
+            sharedConfigPath?.let {
+                add("--config-path")
+                add(it.path)
+            }
+            sharedSecurityPath?.let {
+                add("--security-path")
+                add(it.path)
+            }
+        }
 
     val standardOutput = ByteArrayOutputStream()
     val errorOutput = ByteArrayOutputStream()
     exec {
-        it.executable = "xcrun"
+        it.executable = swiftBinPath ?: "xcrun"
         it.args = args
         it.workingDir = workingDir
         it.standardOutput = standardOutput
@@ -127,24 +130,27 @@ internal fun ExecOperations.getPackageImplicitDependencies(
     workingDir: File,
     scratchPath: File,
     logger: Logger,
+    swiftBinPath: String?,
 ): PackageImplicitDependencies {
     val args =
-        listOf(
-            "--sdk",
-            "macosx",
-            "swift",
-            "package",
-            "show-dependencies",
-            "--scratch-path",
-            scratchPath.path,
-            "--format",
-            "json",
-        )
+        buildList {
+            if (swiftBinPath == null) {
+                add("--sdk")
+                add("macosx")
+                add("swift")
+            }
+            add("package")
+            add("show-dependencies")
+            add("--scratch-path")
+            add(scratchPath.path)
+            add("--format")
+            add("json")
+        }
 
     val standardOutput = ByteArrayOutputStream()
     val errorOutput = ByteArrayOutputStream()
     exec {
-        it.executable = "xcrun"
+        it.executable = swiftBinPath ?: "xcrun"
         it.workingDir = workingDir
         it.args = args
         it.standardOutput = standardOutput

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
@@ -185,6 +185,7 @@ private fun GenerateManifestTask.configureManifestTask(
     this.sharedConfigDir.set(packageDirectoriesConfig.sharedConfigDir)
     this.sharedSecurityDir.set(packageDirectoriesConfig.sharedSecurityDir)
     this.targetSettings.set(swiftPackageEntry.bridgeSettings as BridgeSettings)
+    this.swiftBinPath.set(swiftPackageEntry.swiftBinPath)
 }
 
 private fun GenerateExportableManifestTask.configureExportableManifestTask(
@@ -220,6 +221,7 @@ private fun CompileSwiftPackageTask.configureCompileTask(
     this.sharedCacheDir.set(packageDirectoriesConfig.sharedCacheDir)
     this.sharedConfigDir.set(packageDirectoriesConfig.sharedConfigDir)
     this.sharedSecurityDir.set(packageDirectoriesConfig.sharedSecurityDir)
+    this.swiftBinPath.set(swiftPackageEntry.swiftBinPath)
 }
 
 private fun GenerateCInteropDefinitionTask.configureGenerateCInteropDefinitionTask(
@@ -242,6 +244,7 @@ private fun GenerateCInteropDefinitionTask.configureGenerateCInteropDefinitionTa
     this.packageDependencyPrefix.set(swiftPackageEntry.packageDependencyPrefix)
     this.compilerOpts.set(swiftPackageEntry.compilerOpts)
     this.linkerOpts.set(swiftPackageEntry.linkerOpts)
+    this.swiftBinPath.set(swiftPackageEntry.swiftBinPath)
 }
 
 private fun createCInteropTask(

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/CompileSwiftPackageTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/CompileSwiftPackageTask.kt
@@ -48,6 +48,10 @@ internal abstract class CompileSwiftPackageTask : DefaultTask() {
     @get:Optional
     abstract val sharedSecurityDir: Property<File?>
 
+    @get:Input
+    @get:Optional
+    abstract val swiftBinPath: Property<String?>
+
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val manifestFile: Property<File>
@@ -81,9 +85,11 @@ internal abstract class CompileSwiftPackageTask : DefaultTask() {
 
         val args =
             buildList {
-                add("--sdk")
-                add("macosx")
-                add("swift")
+                if (swiftBinPath.orNull == null) {
+                    add("--sdk")
+                    add("macosx")
+                    add("swift")
+                }
                 add("build")
                 add("--sdk")
                 add(execOps.getSDKPath(target.get(), logger))
@@ -113,7 +119,7 @@ internal abstract class CompileSwiftPackageTask : DefaultTask() {
         val errorOutput = ByteArrayOutputStream()
         execOps
             .exec {
-                it.executable = "xcrun"
+                it.executable = swiftBinPath.orNull ?: "xcrun"
                 it.workingDir = manifestFile.get().parentFile
                 it.args = args
                 it.standardOutput = standardOutput

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/GenerateCInteropDefinitionTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/GenerateCInteropDefinitionTask.kt
@@ -59,6 +59,10 @@ internal abstract class GenerateCInteropDefinitionTask : DefaultTask() {
     @get:Optional
     abstract val packageDependencyPrefix: Property<String?>
 
+    @get:Input
+    @get:Optional
+    abstract val swiftBinPath: Property<String?>
+
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val compiledBinary: RegularFileProperty
@@ -279,6 +283,7 @@ internal abstract class GenerateCInteropDefinitionTask : DefaultTask() {
                             workingDir = manifestFile.asFile.get().parentFile,
                             scratchPath = scratchDir.get(),
                             logger = logger,
+                            swiftBinPath = swiftBinPath.orNull,
                         ).getPublicFolders(),
                 )
                 // extract the header from the SPM artifacts, which there are xcframework

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/GenerateManifestTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/GenerateManifestTask.kt
@@ -59,6 +59,10 @@ internal abstract class GenerateManifestTask : DefaultTask() {
     @get:Input
     abstract val targetSettings: Property<BridgeSettings>
 
+    @get:Input
+    @get:Optional
+    abstract val swiftBinPath: Property<String?>
+
     @get:OutputFile
     abstract val manifestFile: Property<File>
 
@@ -110,7 +114,8 @@ internal abstract class GenerateManifestTask : DefaultTask() {
                 sharedCachePath = sharedCacheDir.orNull,
                 sharedConfigPath = sharedConfigDir.orNull,
                 sharedSecurityPath = sharedSecurityDir.orNull,
-                logger,
+                logger = logger,
+                swiftBinPath = swiftBinPath.orNull,
             )
         } catch (ex: Exception) {
             logger.error(

--- a/website/docs/references/swiftPackageConfig.md
+++ b/website/docs/references/swiftPackageConfig.md
@@ -211,3 +211,14 @@ The block allows specifying various compiler and linker settings needed for the 
 ```kotlin
 fun bridgeSettings(setting: BridgeSettingsConfig.() -> Unit)
 ```
+
+## swiftBinPath
+
+The path of the Swift command line used to build the bridge
+You can change the version of swift used for building the bridge by setting another binary
+
+Default : uses the command `xcrun --sdk macosx swift` by default
+
+```kotlin
+var swiftBinPath: String? = null
+```

--- a/website/docs/setup.md
+++ b/website/docs/setup.md
@@ -3,7 +3,7 @@
 ## Requirement
 
 - macOS With Xcode 16 and later
-    - Using an earlier version of [Xcode is possible](tips.md#support-xcode--16), but I don't recommend it.
+    - Using an earlier version of [Xcode is possible](tips.md#support-xcode-15-and-earlier), but I don't recommend it.
 - Kotlin : **2.1.0 and later**
 - Gradle : **8.10 and later**
 

--- a/website/docs/setup.md
+++ b/website/docs/setup.md
@@ -3,7 +3,7 @@
 ## Requirement
 
 - macOS With Xcode 16 and later
-    - Using an earlier version of Xcode is possible, but I don't recommend it.
+    - Using an earlier version of [Xcode is possible](tips.md#support-xcode--16), but I don't recommend it.
 - Kotlin : **2.1.0 and later**
 - Gradle : **8.10 and later**
 

--- a/website/docs/tips.md
+++ b/website/docs/tips.md
@@ -63,4 +63,25 @@ fun getView(): UIView = TestClass().getViewWithNSObject() as UIView
 fun setView(view: UIView) = TestClass().setViewWithNSObject(view)
 ```
 
+## Support Xcode 15 and earlier
 
+!!! warning "Experimental"
+
+    This is experimental; this tips is not fully tested for every use cases.
+    You can create an issue if needed.
+
+
+As Xcode < 16 is unstable with Swift Package and has some weird behavior.
+It's recommended to use the latest version of the IDE.
+
+But, it is possible to support older versions of Xcode by using a more recent version of the Swift Compiler than the Xcode one.
+
+The property [swiftBinPath](references/swiftPackageConfig.md#swiftbinpath) has been added to change the swift command used by the plugin.
+
+This official tool [swiftly](https://www.swift.org/blog/introducing-swiftly_10/) has been recently added to easily install another version of swift on macOS.
+
+So follow the swiftly guide to install another swift version and set the swiftBinPath property correctly.
+
+```kotlin
+swiftBinPath = "/path/to/.swiftly/bin/swift"
+```


### PR DESCRIPTION
The instability issues with Xcode 15 come from the Swift version of Xcode.

It's possible to use a more recent version of swift than the Xcode one.

So, we have the stability of Swift 6 and the SDK of Xcode 15.

Use [Swiftly](https://www.swift.org/blog/introducing-swiftly_10/) for swift version manager on macos 
