### PR TITLE
Fix dummy.def is directory error

### DIFF
--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/utils/GetAndCreateFakeDefinitionFile.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/utils/GetAndCreateFakeDefinitionFile.kt
@@ -4,12 +4,14 @@ import org.gradle.api.Project
 import java.io.File
 
 internal fun Project.getAndCreateFakeDefinitionFile(): File {
-    val pathToFile =
-        layout.buildDirectory.asFile
-            .get()
-            .resolve("spmKmpPlugin/dummy.def")
-    if (pathToFile.exists()) return pathToFile
-    pathToFile.mkdirs()
+    val pluginDir = layout.buildDirectory.asFile
+        .get()
+        .resolve("spmKmpPlugin")
+    if (!pluginDir.exists()) {
+        pluginDir.mkdirs()
+    }
+    val defFile = pluginDir.resolve("dummy.def")
+    if (defFile.exists()) return defFile
     val content =
         """
         # Dummy Definition File
@@ -20,6 +22,6 @@ internal fun Project.getAndCreateFakeDefinitionFile(): File {
         linkerOpts =
         package = com.example.dummy
         """.trimIndent()
-    pathToFile.writeText(content)
-    return pathToFile
+    defFile.writeText(content)
+    return defFile
 }


### PR DESCRIPTION

## 🚀 Description
Fixes below exception on non-mac device build.

```
Failed to notify project evaluation listener.
   > /home/jenkins/agent/workspace/mobility-android/Aurora/PR-CI-PIPELINE/library/auth/build/spmKmpPlugin/dummy.def (Is a directory)
```

It was occurred because `pathToFile` is a file not directory.

## ✅ Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.