### PR TITLE
Use Automatic copy by default for copy package resources

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Run Gradle tasks
         run: ./gradlew :preMerge :plugin-build:plugin:jacocoTestReport --continue
       - name: build iosExampleApp
-        run: xcodebuild -project iosApp.xcodeproj -scheme iosApp -configuration Debug -destination 'platform=iOS Simulator,name=iPhone SE (3rd generation)' -derivedDataPath "./build" -clonedSourcePackagesDirPath "./spm" test | xcpretty
+        run: xcodebuild -project iosApp.xcodeproj -scheme iosApp -configuration Debug -destination 'platform=iOS Simulator,name=iPhone SE (3rd generation)' -derivedDataPath "./build" -clonedSourcePackagesDirPath "./spm" clean test | xcpretty
         working-directory: "example/iosApp"
       - name: Archive test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -1,0 +1,61 @@
+name: Build and Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - 'website/**'
+      - 'BinaryPackageSource/**'
+      - '.idea/**'
+
+concurrency:
+  # Use a unique identifier for the workflow cancellation group.
+  # Most commonly, the branch name or pull request reference.
+  group: ${{ github.ref }} # Cancels workflows for the same branch or PR
+  cancel-in-progress: true # Automatically cancels in-progress workflows
+
+jobs:
+  gradle:
+    runs-on: macos-latest
+    env:
+      GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+      GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'jetbrains'
+          java-version: '17'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache Konan
+        id: cache-konan
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan
+      - name: Cache example
+        id: cache-example-scratch
+        uses: actions/cache@v4
+        with:
+          path: |
+            example/build/spmKmpPlugin
+            example/iosApp/spm
+            example/iosApp/build
+            example/SPM
+          key: ${{ runner.os }}-example-snapshot
+      - name: Cache Gradle Caches
+        uses: gradle/actions/setup-gradle@v4
+      - name: test iosExampleApp
+        run: xcodebuild -project iosApp.xcodeproj -scheme iosApp -configuration Debug -destination 'platform=iOS Simulator,name=iPhone SE (3rd generation)' -derivedDataPath "./build" -clonedSourcePackagesDirPath "./spm" clean test | xcpretty
+        working-directory: "example/iosApp"

--- a/example/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/example/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -231,7 +231,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/../../\"\n./gradlew :example:nativeIosSharedCopyPackageResources\n";
+			shellScript = "#cd \"$SRCROOT/../../\"\n#./gradlew :example:nativeIosSharedCopyPackageResources\n";
 		};
 		7555FFB5242A651A00829871 /* build framework */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -1,5 +1,5 @@
 ID=io.github.frankois944.spmForKmp
-VERSION=0.10.1
+VERSION=0.11.0
 ARTIFACT_ID=Spm4Kmp
 GROUP=io.github.frankois944
 DISPLAY_NAME=Swift Package Manager for Kotlin Multiplaform

--- a/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/CopyResourcesTest.kt
+++ b/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/CopyResourcesTest.kt
@@ -126,10 +126,10 @@ class CopyResourcesTest : BaseTest() {
         val parameters =
             buildList {
                 add("dummyCopyPackageResources")
-                add("-PPLATFORM_NAME=iphone")
-                add("-PARCHS=arm64")
-                add("-PBUILT_PRODUCTS_DIR=$appBuiltProductDir")
-                add("-PCONTENTS_FOLDER_PATH=$appContentFolderPath")
+                add("-Pio.github.frankois944.spmForKmp.PLATFORM_NAME=iphone")
+                add("-Pio.github.frankois944.spmForKmp.ARCHS=arm64")
+                add("-Pio.github.frankois944.spmForKmp.BUILT_PRODUCTS_DIR=$appBuiltProductDir")
+                add("-Pio.github.frankois944.spmForKmp.CONTENTS_FOLDER_PATH=$appContentFolderPath")
             }
 
         // When I build the project

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/resources/CopiedResourcesFactory.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/resources/CopiedResourcesFactory.kt
@@ -20,131 +20,115 @@ internal data class FrameworkResource(
 
 @Suppress("LongParameterList")
 internal class CopiedResourcesFactory(
-    private val packageScratchDir: File,
-    baseDir: File,
-    private val platformName: String,
-    private val archs: String,
-    private val buildPackageMode: String,
+    private val inputBuiltDirectory: File,
     contentFolderPath: String,
     buildProductDir: String,
     private val logger: Logger,
 ) {
     val outputBundleDirectory: File
     val outputFrameworkDirectory: File
-    val frameworks: List<FrameworkResource>
-    val bundles: List<File>
+    val frameworks: List<FrameworkResource> =
+        buildList {
+            inputBuiltDirectory
+                .listFiles {
+                    it.extension == "framework"
+                }.forEach { framework ->
+                    val plist = framework.resolve("Info.plist")
+                    logger.debug("Looking inside the Info.plist {}", plist)
+                    val libraryName = getPlistValue(plist, "CFBundleExecutable")
+                    logger.debug("Found libraryName $libraryName")
+                    val binaryFile = framework.resolve(libraryName)
+                    val newFramework = FrameworkResource(framework, binaryFile = binaryFile)
+                    add(newFramework)
+                }
+        }
+    val bundles: List<File> =
+        buildList {
+            // get all bundle folders from build directory
+            inputBuiltDirectory
+                .listFiles {
+                    it.extension == "bundle"
+                }.let {
+                    addAll(it)
+                }
+            // get all bundles from frameworks
+            inputBuiltDirectory
+                .listFiles {
+                    it.extension == "framework"
+                }.forEach { framework ->
+                    framework
+                        .listFiles {
+                            it.extension == "bundle"
+                        }?.let {
+                            addAll(it)
+                        }
+                }
+        }
 
     init {
-        val inputBuiltDirectory =
-            getCurrentPackagesBuiltDir(
-                packageScratchDir = packageScratchDir,
-                platformName = platformName,
-                archs = archs,
-                buildPackageMode = buildPackageMode,
-                logger = logger,
-            )
-
-        bundles =
-            buildList {
-                // get all bundle folders from build directory
-                inputBuiltDirectory
-                    .listFiles {
-                        it.extension == "bundle"
-                    }.let {
-                        addAll(it)
-                    }
-                // get all bundles from frameworks
-                inputBuiltDirectory
-                    .listFiles {
-                        it.extension == "framework"
-                    }.forEach { framework ->
-                        framework
-                            .listFiles {
-                                it.extension == "bundle"
-                            }?.let {
-                                addAll(it)
-                            }
-                    }
-            }
-
-        frameworks =
-            buildList {
-                inputBuiltDirectory
-                    .listFiles {
-                        it.extension == "framework"
-                    }.forEach { framework ->
-                        val plist = framework.resolve("Info.plist")
-                        logger.debug("Looking inside the Info.plist {}", plist)
-                        val libraryName = getPlistValue(plist, "CFBundleExecutable")
-                        logger.debug("Found libraryName $libraryName")
-                        val binaryFile = framework.resolve(libraryName)
-                        val newFramework = FrameworkResource(framework, binaryFile = binaryFile)
-                        add(newFramework)
-                    }
-            }
 
         val destinationDir = Path(buildProductDir, contentFolderPath).toFile()
 
-        outputBundleDirectory = destinationDir.relativeTo(baseDir)
-        outputFrameworkDirectory = destinationDir.resolve("Frameworks").relativeTo(baseDir)
+        outputBundleDirectory = destinationDir
+        outputFrameworkDirectory = destinationDir.resolve("Frameworks")
         logger.debug("outputBundleDirectory: {}", outputBundleDirectory)
         logger.debug("outputFrameworkDirectory: {}", outputFrameworkDirectory)
         logger.debug("inputBundles: {}", bundles.map { it.name })
         logger.debug("inputFrameworks: {}", frameworks.map { it.name + it.files.map { f -> f.name } })
     }
+}
 
-    private fun getCurrentPackagesBuiltDir(
-        packageScratchDir: File,
-        platformName: String,
-        archs: String,
-        buildPackageMode: String,
-        logger: Logger,
-    ): File {
-        logger.debug("Looking for a match with platformName $platformName")
-        val systemType: String? =
-            when {
-                platformName.contains("iphone") -> {
-                    "ios"
-                }
-
-                platformName.contains("watch") -> {
-                    "watchos"
-                }
-
-                platformName.contains("mac") -> {
-                    "macosx"
-                }
-
-                platformName.contains("tv") -> {
-                    "tvos"
-                }
-
-                else -> {
-                    null
-                }
+internal fun getCurrentPackagesBuiltDir(
+    packageScratchDir: File,
+    platformName: String,
+    archs: String,
+    buildPackageMode: String,
+    logger: Logger,
+): File {
+    logger.debug("Looking for a match with platformName $platformName")
+    val systemType: String? =
+        when {
+            platformName.contains("iphone") -> {
+                "ios"
             }
-        if (systemType == null) {
-            throw RuntimeException("No matching systemType from platformName $platformName")
-        }
-        val simulator: String =
-            if (platformName.contains("simulator")) {
-                "-simulator"
-            } else {
-                ""
+
+            platformName.contains("watch") -> {
+                "watchos"
             }
-        val buildPackageDirName = "$archs-apple-$systemType$simulator"
-        logger.debug("buildPackageDir created $buildPackageDirName")
-        val buildPackagePath =
-            packageScratchDir
-                .resolve(buildPackageDirName)
-                .resolve(buildPackageMode)
-                .toPath()
-        if (!buildPackagePath.exists()) {
-            logger.error("The buildPackagePath doesn't exist at $buildPackagePath")
-            throw RuntimeException("Can't find the package build dir")
-        } else {
-            logger.debug("Found {} as packages resources path", buildPackagePath)
+
+            platformName.contains("mac") -> {
+                "macosx"
+            }
+
+            platformName.contains("tv") -> {
+                "tvos"
+            }
+
+            else -> {
+                null
+            }
         }
-        return buildPackagePath.toFile()
+    if (systemType == null) {
+        throw RuntimeException("No matching systemType from platformName $platformName")
     }
+    val simulator: String =
+        if (platformName.contains("simulator")) {
+            "-simulator"
+        } else {
+            ""
+        }
+    val buildPackageDirName = "$archs-apple-$systemType$simulator"
+    logger.debug("buildPackageDir created $buildPackageDirName")
+    val buildPackagePath =
+        packageScratchDir
+            .resolve(buildPackageDirName)
+            .resolve(buildPackageMode)
+            .toPath()
+    if (!buildPackagePath.exists()) {
+        logger.error("The buildPackagePath doesn't exist at $buildPackagePath")
+        throw RuntimeException("Can't find the package build dir")
+    } else {
+        logger.debug("Found {} as packages resources path", buildPackagePath)
+    }
+    return buildPackagePath.toFile()
 }

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
@@ -301,18 +301,24 @@ private fun CopyPackageResourcesTask.configureCopyPackageResourcesTask(
         return
     }
     val buildProductDir: String? =
-        project.findProperty("io.github.frankois944.spmForKmp.BUILT_PRODUCTS_DIR") as? String ?: System.getenv("BUILT_PRODUCTS_DIR")
+        project.findProperty("io.github.frankois944.spmForKmp.BUILT_PRODUCTS_DIR") as? String
+            ?: System.getenv("BUILT_PRODUCTS_DIR")
     val contentFolderPath: String? =
-        project.findProperty("io.github.frankois944.spmForKmp.CONTENTS_FOLDER_PATH") as? String ?: System.getenv("CONTENTS_FOLDER_PATH")
-    val archs: String? = project.findProperty("io.github.frankois944.spmForKmp.ARCHS") as? String ?: System.getenv("ARCHS")
+        project.findProperty("io.github.frankois944.spmForKmp.CONTENTS_FOLDER_PATH") as? String
+            ?: System.getenv("CONTENTS_FOLDER_PATH")
+    val archs: String? =
+        project.findProperty("io.github.frankois944.spmForKmp.ARCHS") as? String
+            ?: System.getenv("ARCHS")
     val platformName: String? =
-        project.findProperty("io.github.frankois944.spmForKmp.PLATFORM_NAME") as? String ?: System.getenv("PLATFORM_NAME")
+        project.findProperty("io.github.frankois944.spmForKmp.PLATFORM_NAME") as? String
+            ?: System.getenv("PLATFORM_NAME")
 
     logger.debug("buildProductDir $buildProductDir")
     logger.debug("contentFolderPath $contentFolderPath")
     logger.debug("archs $archs")
     logger.debug("platformName $platformName")
 
+    @Suppress("ComplexCondition")
     if (archs.isNullOrEmpty() ||
         platformName.isNullOrEmpty() ||
         buildProductDir.isNullOrEmpty() ||

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/CopyPackageResourcesTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/CopyPackageResourcesTask.kt
@@ -1,67 +1,76 @@
 package io.github.frankois944.spmForKmp.tasks.apple
 
 import io.github.frankois944.spmForKmp.operations.isDynamicLibrary
-import io.github.frankois944.spmForKmp.resources.FrameworkResource
+import io.github.frankois944.spmForKmp.resources.CopiedResourcesFactory
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
+import org.jetbrains.kotlin.konan.target.HostManager
 import java.io.File
 import javax.inject.Inject
 
 @CacheableTask
 internal abstract class CopyPackageResourcesTask : DefaultTask() {
-    @get:Input
-    abstract val inputFrameworks: ListProperty<FrameworkResource>
-
-    @get:InputFiles
+    @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val listOfResourcesToCopy: ListProperty<File>
-
-    @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val inputBundles: ListProperty<File>
-
-    @get:OutputDirectory
-    abstract val outputFrameworkDirectory: DirectoryProperty
-
-    @get:OutputDirectory
-    abstract val outputBundleDirectory: DirectoryProperty
+    abstract val builtDirectory: DirectoryProperty
 
     @get:Inject
     abstract val execOps: ExecOperations
 
+    @get:Input
+    abstract val buildProductDir: Property<String>
+
+    @get:Input
+    abstract val contentFolderPath: Property<String>
+
     init {
         description = "Copy package resource to application"
         group = "io.github.frankois944.spmForKmp.tasks"
+        onlyIf {
+            HostManager.hostIsMac
+        }
     }
 
     @TaskAction
     fun copyResources() {
+        logger.debug("preparing resources")
+        val copiedResources =
+            CopiedResourcesFactory(
+                inputBuiltDirectory = builtDirectory.get().asFile,
+                contentFolderPath = contentFolderPath.get(),
+                buildProductDir = buildProductDir.get(),
+                logger = logger,
+            )
+
         logger.debug("Start copy bundle resources")
-        inputBundles.get().forEach {
-            val destination = File(outputBundleDirectory.asFile.get(), it.name)
-            logger.debug("copy resources bundle {} to {}", it, outputBundleDirectory.get())
+        copiedResources.bundles.forEach {
+            val destination = File(copiedResources.outputBundleDirectory, it.name)
+            logger.debug("copy resources bundle {} to {}", it.absolutePath, destination.absolutePath)
             it.copyRecursively(destination, overwrite = true)
         }
         logger.debug("End copy bundle resources")
 
         logger.debug("Start copy framework resources")
         val buildFrameworkDir =
-            outputFrameworkDirectory.asFile
-                .get()
-                .parentFile.parentFile
-        val builtAppDir = outputFrameworkDirectory.asFile.get()
-        listOf(buildFrameworkDir, builtAppDir).forEach { appDir ->
-            inputFrameworks
-                .get()
+            copiedResources.outputFrameworkDirectory
+                .parentFile
+                .parentFile
+        val builtAppDir =
+            copiedResources
+                .outputFrameworkDirectory
+        listOf(
+            buildFrameworkDir,
+            builtAppDir,
+        ).forEach { appDir ->
+            copiedResources.frameworks
                 .filter { framework ->
                     // A static framework/library can't be copied to the app.
                     // A dynamic library and his resources must be copied inside the Apple app.
@@ -92,7 +101,7 @@ internal abstract class CopyPackageResourcesTask : DefaultTask() {
                     }
                     logger.debug("copy framework {} to {}", framework.name, destination)
                     framework.files.forEach { file ->
-                        logger.debug("copy framework file ${file.name} to ${destination.resolve(file.name).path}")
+                        logger.debug("copy framework file ${file.name} to ${destination.resolve(file.name)}")
                         file.copyRecursively(
                             destination.resolve(file.name),
                             overwrite = true,


### PR DESCRIPTION
Remove the need to declare a task in xcode build phase to trigger the copy of the resources

Only `copyDependenciesToApp` is now required