### PR TITLE
162 spm4kmp fails to handle library based c xcframework

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -93,6 +93,9 @@ swiftPackageConfig {
         // packageDependencyPrefix = null // default null
         spmWorkingPath = "${projectDir.resolve("SPM")}" // change the Swift Package Manager working Dir
         // swiftBinPath = "/path/to/.swiftly/bin/swift"
+        // exportedPackageSettings {
+        //     includeProduct = listOf("HevSocks5Tunnel")
+        // }
         minIos = "16.0"
         dependency {
             remotePackageVersion(
@@ -104,7 +107,6 @@ swiftPackageConfig {
                     add(ProductName("FirebaseCore"), exportToKotlin = true)
                     // add FirebaseDatabase to your own swift code but don't export it
                     add(ProductName("FirebaseDatabase"))
-                    add("FirebaseAuth", exportToKotlin = true)
                 },
                 // (Optional) Package name, can be required in some cases
                 packageName = "firebase-ios-sdk",
@@ -139,6 +141,13 @@ swiftPackageConfig {
                     // Can be only used in your "src/swift" code.
                     add("CryptoSwift")
                 },
+            )
+            remoteBinary(
+                url = uri("https://github.com/wanliyunyan/HevSocks5Tunnel/releases/download/2.10.0/HevSocks5Tunnel.xcframework.zip"),
+                packageName = "HevSocks5Tunnel",
+                exportToKotlin = true,
+                checksum = "f66fc314edbdb7611c5e8522bc50ee62e7930f37f80631b8d08b2a40c81a631a",
+                isCLang = true,
             )
         }
     }

--- a/example/exportedNativeIosShared/Package.swift
+++ b/example/exportedNativeIosShared/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     .library(
       name: "exportedNativeIosShared",
       type: .static,
-      targets: ["exportedNativeIosShared"])
+      targets: ["exportedNativeIosShared", "HevSocks5Tunnel"])
   ],
   dependencies: [
     .package(url: "https://github.com/firebase/firebase-ios-sdk.git", exact: "12.3.0")
@@ -17,11 +17,15 @@ let package = Package(
     .target(
       name: "exportedNativeIosShared",
       dependencies: [
-        .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk")
+        .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"), "HevSocks5Tunnel",
       ],
       path: "Sources"
 
-    )
-
+    ),
+    .binaryTarget(
+      name: "HevSocks5Tunnel",
+      url:
+        "https://github.com/wanliyunyan/HevSocks5Tunnel/releases/download/2.10.0/HevSocks5Tunnel.xcframework.zip",
+      checksum: "f66fc314edbdb7611c5e8522bc50ee62e7930f37f80631b8d08b2a40c81a631a"),
   ]
 )

--- a/example/src/iosMain/kotlin/com/example/Platform.ios.kt
+++ b/example/src/iosMain/kotlin/com/example/Platform.ios.kt
@@ -5,6 +5,7 @@ package com.example
 import DummyFramework.MyDummyFramework
 import FirebaseAnalytics.FIRConsentStatusGranted
 import FirebaseCore.FIRApp
+import HevSocks5Tunnel.hev_socks5_tunnel_quit
 import kotlinx.cinterop.ExperimentalForeignApi
 import nativeIosShared.MySwiftDummyClass
 import nativeIosShared.TestClass
@@ -18,6 +19,10 @@ class IOSPlatform : Platform {
 
     override val name: String =
         UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
+}
+
+fun test() {
+    hev_socks5_tunnel_quit()
 }
 
 actual fun getPlatform(): Platform = IOSPlatform()

--- a/example/src/swift/nativeIosShared/SpmForSwiftSource.swift
+++ b/example/src/swift/nativeIosShared/SpmForSwiftSource.swift
@@ -3,6 +3,7 @@ import UIKit
 
 import CryptoSwift
 import FirebaseDatabase
+import HevSocks5Tunnel
 
 // Force cinterop to include `platform.UIKit.UIView`
 @objcMembers public class MyDummyView: UIView {}
@@ -34,6 +35,10 @@ import FirebaseDatabase
 
     public func doAsyncStuff() async {
         print("Nothing")
+    }
+
+    public func cMethod() {
+        hev_socks5_tunnel_quit()
     }
 }
 

--- a/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/CLanguageBinaryPackageTest.kt
+++ b/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/CLanguageBinaryPackageTest.kt
@@ -1,0 +1,66 @@
+package io.github.frankois944.spmForKmp
+
+import com.autonomousapps.kit.GradleBuilder
+import com.autonomousapps.kit.truth.TestKitTruth.Companion.assertThat
+import io.github.frankois944.spmForKmp.fixture.KotlinSource
+import io.github.frankois944.spmForKmp.fixture.SmpKMPTestFixture
+import io.github.frankois944.spmForKmp.fixture.SwiftSource
+import io.github.frankois944.spmForKmp.utils.BaseTest
+import org.junit.jupiter.api.Test
+
+class CLanguageBinaryPackageTest : BaseTest() {
+    @Test
+    fun `build with remote binary with C language package`() {
+        // Given
+        val fixture =
+            SmpKMPTestFixture
+                .builder()
+                .withBuildPath(testProjectDir.root.absolutePath)
+                .withRawDependencies(
+                    KotlinSource.of(
+                        content =
+                            """
+                            remoteBinary(
+                                url = uri("https://github.com/wanliyunyan/HevSocks5Tunnel/releases/download/2.10.0/HevSocks5Tunnel.xcframework.zip"),
+                                packageName = "HevSocks5Tunnel",
+                                exportToKotlin = true,
+                                checksum = "f66fc314edbdb7611c5e8522bc50ee62e7930f37f80631b8d08b2a40c81a631a",
+                                isCLang = true,
+                            )
+                            """.trimIndent(),
+                    ),
+                ).withKotlinSources(
+                    KotlinSource.of(
+                        imports = listOf("HevSocks5Tunnel.hev_socks5_tunnel_quit"),
+                        content =
+                            """
+                            @OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+                            fun test() {
+                                hev_socks5_tunnel_quit()
+                            }
+                            """.trimIndent(),
+                    ),
+                ).withSwiftSources(
+                    SwiftSource.of(
+                        content =
+                            """
+                            import Foundation
+                            import HevSocks5Tunnel
+                            @objc public class MySwiftClass: NSObject {
+                                public func cMethod() {
+                                    hev_socks5_tunnel_quit()
+                                }
+                            }
+                            """.trimIndent(),
+                    ),
+                ).build()
+
+        val result =
+            GradleBuilder
+                .runner(fixture.gradleProject.rootDir, "build")
+                .build()
+
+        // Then
+        assertThat(result).task(":library:build").succeeded()
+    }
+}

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/config/ModuleConfig.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/config/ModuleConfig.kt
@@ -2,17 +2,20 @@ package io.github.frankois944.spmForKmp.config
 
 import io.github.frankois944.spmForKmp.definition.SwiftDependency
 import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.Path
 
 internal data class ModuleConfig(
     var isFramework: Boolean = false,
     var name: String = "",
     var spmPackageName: String? = null,
     var packageName: String = "",
-    var buildDir: File = File(""),
+    var buildDir: Path = Path(""),
     var definitionFile: File = File(""),
     var linkerOpts: List<String> = emptyList(),
     var compilerOpts: List<String> = emptyList(),
     var swiftDependency: SwiftDependency? = null,
+    var isCLang: Boolean = false,
 )
 
 internal fun List<ModuleConfig>.containsPackage(name: String): Boolean =

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/definition/SwiftDependency.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/definition/SwiftDependency.kt
@@ -34,10 +34,13 @@ internal sealed interface SwiftDependency : Serializable {
          */
         val exportToKotlin: Boolean
 
+        val isCLang: Boolean
+
         data class Local(
             val path: String,
             override val packageName: String,
             override val exportToKotlin: Boolean = false,
+            override val isCLang: Boolean = false,
         ) : Binary
 
         data class Remote(
@@ -45,6 +48,7 @@ internal sealed interface SwiftDependency : Serializable {
             override val packageName: String,
             override val exportToKotlin: Boolean = false,
             val checksum: String,
+            override val isCLang: Boolean = false,
         ) : Binary
     }
 

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/definition/dependency/Dependency.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/definition/dependency/Dependency.kt
@@ -14,12 +14,14 @@ internal class Dependency :
         path: String,
         packageName: String,
         exportToKotlin: Boolean,
+        isCLang: Boolean,
     ) {
         packageDependencies.add(
             SwiftDependency.Binary.Local(
                 path = path,
                 packageName = packageName,
                 exportToKotlin = exportToKotlin,
+                isCLang = isCLang,
             ),
         )
     }
@@ -29,6 +31,7 @@ internal class Dependency :
         packageName: String,
         exportToKotlin: Boolean,
         checksum: String,
+        isCLang: Boolean,
     ) {
         packageDependencies.add(
             SwiftDependency.Binary.Remote(
@@ -36,6 +39,7 @@ internal class Dependency :
                 packageName = packageName,
                 exportToKotlin = exportToKotlin,
                 checksum = checksum,
+                isCLang = isCLang,
             ),
         )
     }

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/definition/dependency/DependencyConfig.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/definition/dependency/DependencyConfig.kt
@@ -1,6 +1,7 @@
 package io.github.frankois944.spmForKmp.definition.dependency
 
 import io.github.frankois944.spmForKmp.definition.product.dsl.ProductPackageConfig
+import io.github.frankois944.spmForKmp.utils.ExperimentalSpmForKmpFeature
 import java.io.Serializable
 import java.net.URI
 
@@ -14,11 +15,13 @@ public interface DependencyConfig : Serializable {
      * @property path The local file URL (file://...) to the xcFramework.
      * @property packageName The name of the package associated with this binary.
      * @property exportToKotlin Defines whether the dependency should be exported for use in Kotlin code.
+     * @property isCLang Specify if the binary is a C language framework.
      */
     public fun localBinary(
         path: String,
         packageName: String,
         exportToKotlin: Boolean = false,
+        isCLang: Boolean = false,
     )
 
     @Suppress("MaxLineLength")
@@ -31,12 +34,14 @@ public interface DependencyConfig : Serializable {
      * @property packageName The name of the package associated with this binary dependency.
      * @property exportToKotlin Defines whether this dependency should be exported for use in Kotlin code.
      * @property checksum The checksum of the remote binary to verify its integrity.
+     * @property isCLang Specify if the binary is a C language framework.
      */
     public fun remoteBinary(
         url: URI,
         packageName: String,
         exportToKotlin: Boolean = false,
         checksum: String,
+        isCLang: Boolean = false,
     )
 
     /**

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/GenerateCInteropDefinitionTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/GenerateCInteropDefinitionTask.kt
@@ -245,10 +245,14 @@ internal abstract class GenerateCInteropDefinitionTask : DefaultTask() {
         moduleConfigs.forEachIndexed { index, moduleConfig ->
             logger.debug("Building definition file for: {}", moduleConfig)
             try {
-                val mapFile = getModuleMap(moduleConfig)
                 val moduleName =
-                    extractModuleNameFromModuleMap(mapFile.readText())
-                        ?: throw Exception("No module name for ${moduleConfig.name} in mapFile ${mapFile.path}")
+                    if (moduleConfig.isCLang) {
+                        moduleConfig.name
+                    } else {
+                        val mapFile = getModuleMap(moduleConfig)
+                        extractModuleNameFromModuleMap(mapFile.readText())
+                            ?: throw Exception("No module name for ${moduleConfig.name} in mapFile ${mapFile.path}")
+                    }
                 val definition =
                     if (moduleConfig.isFramework) {
                         if (moduleConfig.isCLang) {

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/GenerateExportableManifestTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/GenerateExportableManifestTask.kt
@@ -103,7 +103,6 @@ internal abstract class GenerateExportableManifestTask : DefaultTask() {
                                     name = product.name,
                                     packageName = dependency.packageName,
                                     spmPackageName = dependency.packageName,
-                                    swiftDependency = dependency,
                                 )
                             }
                     }
@@ -114,6 +113,7 @@ internal abstract class GenerateExportableManifestTask : DefaultTask() {
                                 name = dependency.packageName,
                                 spmPackageName = dependency.packageName,
                                 swiftDependency = dependency,
+                                isCLang = dependency.isCLang,
                             ),
                         )
                     }
@@ -201,7 +201,9 @@ internal abstract class GenerateExportableManifestTask : DefaultTask() {
         logger.debug("ALL MODULE {}", modules)
         val moduleToInclude = includeProduct.get().map { it.lowercase() }
         modules.forEach { module ->
-            if (moduleToInclude.contains(module.name.lowercase())) {
+            if (module.isCLang) {
+                requireDependencies.add(module)
+            } else if (moduleToInclude.contains(module.name.lowercase())) {
                 requireDependencies.add(module)
             } else {
                 compiledTargetDir

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/utils/GenerateCInteropDefinitionUtils.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/utils/GenerateCInteropDefinitionUtils.kt
@@ -6,6 +6,9 @@ import io.github.frankois944.spmForKmp.tasks.apple.GenerateCInteropDefinitionTas
 import io.github.frankois944.spmForKmp.utils.extractTargetBlocks
 import io.github.frankois944.spmForKmp.utils.findFilesRecursively
 import java.io.File
+import java.nio.file.Path
+import kotlin.io.resolve
+import kotlin.text.lowercase
 
 internal fun findIncludeFolders(path: File): List<File> =
     findFilesRecursively(
@@ -28,6 +31,20 @@ internal fun findHeadersModule(
         },
         withDirectory = true,
     )
+
+internal fun getModuleArtifactsPath(
+    fromPath: Path,
+    productName: String,
+    moduleConfig: ModuleConfig,
+    target: AppleCompileTarget,
+): Path =
+    fromPath
+        .resolve("artifacts")
+        .resolve(productName.lowercase())
+        .resolve(moduleConfig.name)
+        .resolve("${moduleConfig.name}.xcframework")
+        .resolve(target.xcFrameworkArchName())
+
 
 internal fun getModulesInBuildDirectory(buildDir: File): List<File> {
     val extensions = listOf("build", "framework")


### PR DESCRIPTION
# Add C Language base xcframework

You can now add C xcframework inside the plugin, and you can export it to Kotlin or use it directly inside the bridge.

## Experimental

Currently experimental, I don't have enough feedback to be sure if the file structure is the same everywhere.

Tested with the [HevSocks5Tunnel](https://github.com/wanliyunyan/HevSocks5Tunnel) framework. 
