### PR TITLE
fix gradle isolated projects - no more findProperty usages

### DIFF
--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/copyPackageResources/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/copyPackageResources/ConfigureTask.kt
@@ -5,6 +5,7 @@ import io.github.frankois944.spmForKmp.config.AppleCompileTarget
 import io.github.frankois944.spmForKmp.config.PackageDirectoriesConfig
 import io.github.frankois944.spmForKmp.resources.getCurrentPackagesBuiltDir
 import io.github.frankois944.spmForKmp.tasks.utils.isTraceEnabled
+import org.gradle.api.Project
 
 internal fun CopyPackageResourcesTask.configureTask(
     packageDirectoriesConfig: PackageDirectoriesConfig,
@@ -12,16 +13,16 @@ internal fun CopyPackageResourcesTask.configureTask(
     cinteropTarget: AppleCompileTarget,
 ) {
     val buildProductDir: String? =
-        project.findProperty("io.github.frankois944.spmForKmp.BUILT_PRODUCTS_DIR") as? String
+        project.propertyOrNull("io.github.frankois944.spmForKmp.BUILT_PRODUCTS_DIR") as? String
             ?: System.getenv("BUILT_PRODUCTS_DIR")
     val contentFolderPath: String? =
-        project.findProperty("io.github.frankois944.spmForKmp.CONTENTS_FOLDER_PATH") as? String
+        project.propertyOrNull("io.github.frankois944.spmForKmp.CONTENTS_FOLDER_PATH") as? String
             ?: System.getenv("CONTENTS_FOLDER_PATH")
     val archs: String? =
-        project.findProperty("io.github.frankois944.spmForKmp.ARCHS") as? String
+        project.propertyOrNull("io.github.frankois944.spmForKmp.ARCHS") as? String
             ?: System.getenv("ARCHS")
     val platformName: String? =
-        project.findProperty("io.github.frankois944.spmForKmp.PLATFORM_NAME") as? String
+        project.propertyOrNull("io.github.frankois944.spmForKmp.PLATFORM_NAME") as? String
             ?: System.getenv("PLATFORM_NAME")
 
     logger.debug("buildProductDir $buildProductDir")
@@ -71,4 +72,13 @@ internal fun CopyPackageResourcesTask.configureTask(
             .resolve(packageDirectoriesConfig.spmWorkingDir.name)
             .resolve("CopyPackageResourcesTask.html"),
     )
+}
+
+private fun Project.propertyOrNull(key: String): Any? {
+    val container = project.extensions.extraProperties
+    var result: Any? = null
+    if (container.has(key)) {
+        result = container.get(key)
+    }
+    return result
 }


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
`findProperty` is not safe for use with isolated projects. Replaced it with a simple propertyOrNull call.

## 📄 Motivation and Context
This is the last plugin I use that isn't compatible with isolated projects!

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested by building my own app with `org.gradle.unsafe.isolated-projects=true`. Successful build, no more errors!

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.