### PR TITLE
Fix Simulator `CopyPackageResourcesTask` When Xcode Exports Multi-Arch `ARCHS` Environment Variable

### DIFF
--- a/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/CopyResourcesTest.kt
+++ b/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/CopyResourcesTest.kt
@@ -168,4 +168,70 @@ class CopyResourcesTest : BaseTest() {
             destination.deleteRecursively()
         }
     }
+
+    @Test
+    fun `copy resources task works when simulator ARCHS has multiple values`() {
+        // Given
+        val fixture =
+            SmpKMPTestFixture
+                .builder()
+                .withBuildPath(testProjectDir.root.absolutePath)
+                .withTargets(AppleCompileTarget.iosSimulatorArm64)
+                .build()
+
+        val appBuiltProductDir = "/tmp/resource-test-multi-arch/"
+        val appContentFolderPath = "iphone-sim-test"
+        val destination = Path(appBuiltProductDir, appContentFolderPath)
+        destination.createDirectories()
+
+        val parameters =
+            buildList {
+                add("SwiftPackageConfigAppleDummyCopyPackageResourcesIosSimulatorArm64")
+                add("-Pio.github.frankois944.spmForKmp.PLATFORM_NAME=iphonesimulator")
+                add("-Pio.github.frankois944.spmForKmp.ARCHS=arm64 x86_64")
+                add("-Pio.github.frankois944.spmForKmp.BUILT_PRODUCTS_DIR=$appBuiltProductDir")
+                add("-Pio.github.frankois944.spmForKmp.CONTENTS_FOLDER_PATH=$appContentFolderPath")
+            }
+
+        // When
+        val buildTask =
+            GradleBuilder
+                .runner(
+                    fixture.gradleProject.rootDir,
+                    "build",
+                ).build()
+
+        assertThat(buildTask).task(":library:build").succeeded()
+
+        val copyResourceTask =
+            GradleBuilder
+                .runner(
+                    fixture.gradleProject.rootDir,
+                    *parameters.toTypedArray(),
+                ).build()
+
+        // Then
+        assertThat(copyResourceTask)
+            .task(":library:SwiftPackageConfigAppleDummyCopyPackageResourcesIosSimulatorArm64")
+            .succeeded()
+        val scratchDir =
+            fixture.gradleProject.rootDir
+                .resolve("library")
+                .resolve("build")
+                .resolve("spmKmpPlugin")
+                .resolve("dummy")
+                .resolve("scratch")
+        val expectedBuildDir = scratchDir.resolve("arm64-apple-ios-simulator").resolve("release")
+        val incorrectBuildDir = scratchDir.resolve("arm64 x86_64-apple-ios-simulator").resolve("release")
+        assert(expectedBuildDir.exists()) {
+            "Expected target build directory to exist at ${expectedBuildDir.absolutePath}"
+        }
+        assert(!incorrectBuildDir.exists()) {
+            "Unexpected multi-arch build directory should not exist at ${incorrectBuildDir.absolutePath}"
+        }
+
+        if (destination.exists()) {
+            destination.deleteRecursively()
+        }
+    }
 }

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/copyPackageResources/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/copyPackageResources/ConfigureTask.kt
@@ -3,7 +3,6 @@ package io.github.frankois944.spmForKmp.tasks.apple.copyPackageResources
 import io.github.frankois944.spmForKmp.SPM_TRACE_NAME
 import io.github.frankois944.spmForKmp.config.AppleCompileTarget
 import io.github.frankois944.spmForKmp.config.PackageDirectoriesConfig
-import io.github.frankois944.spmForKmp.resources.getCurrentPackagesBuiltDir
 import io.github.frankois944.spmForKmp.tasks.utils.isTraceEnabled
 import org.gradle.api.Project
 
@@ -18,21 +17,16 @@ internal fun CopyPackageResourcesTask.configureTask(
     val contentFolderPath: String? =
         project.propertyOrNull("io.github.frankois944.spmForKmp.CONTENTS_FOLDER_PATH") as? String
             ?: System.getenv("CONTENTS_FOLDER_PATH")
-    val archs: String? =
-        project.propertyOrNull("io.github.frankois944.spmForKmp.ARCHS") as? String
-            ?: System.getenv("ARCHS")
     val platformName: String? =
         project.propertyOrNull("io.github.frankois944.spmForKmp.PLATFORM_NAME") as? String
             ?: System.getenv("PLATFORM_NAME")
 
     logger.debug("buildProductDir $buildProductDir")
     logger.debug("contentFolderPath $contentFolderPath")
-    logger.debug("archs $archs")
     logger.debug("platformName $platformName")
 
     @Suppress("ComplexCondition")
-    if (archs.isNullOrEmpty() ||
-        platformName.isNullOrEmpty() ||
+    if (platformName.isNullOrEmpty() ||
         buildProductDir.isNullOrEmpty() ||
         contentFolderPath.isNullOrEmpty()
     ) {
@@ -52,13 +46,9 @@ internal fun CopyPackageResourcesTask.configureTask(
     }
 
     this.builtDirectory.set(
-        getCurrentPackagesBuiltDir(
-            packageScratchDir = packageDirectoriesConfig.packageScratchDir,
-            platformName = platformName,
-            archs = archs,
-            buildPackageMode = buildMode,
-            logger = logger,
-        ),
+        packageDirectoriesConfig.packageScratchDir
+            .resolve(cinteropTarget.packageBuildDirName())
+            .resolve(buildMode),
     )
     this.codeSignIdentityName.set(
         System.getenv("EXPANDED_CODE_SIGN_IDENTITY") ?: System.getenv("EXPANDED_CODE_SIGN_IDENTITY_NAME"),


### PR DESCRIPTION
## 🚀 Description

_Before I go on, I'd just like to take a moment to express deep gratitude for the work you're doing here @frankois944 - it's sincerely appreciated. You've put together a plugin that targets (what I perceive to be) a critical gap in the Kotlin Multiplatform development landscape. **Seriously epic stuff!** 🙏_ 

### Summary 

This PR fixes iOS Simulator build failures originating from `spm4Kmp` when Xcode provides a multi-value `ARCHS` string (for example `arm64 x86_64`) for generic simulator destinations.

> [!IMPORTANT]
> The issue that this PR aims to remedy is surfacing for me in projects that only target Apple Silicon architectures (i.e. no Intel Simulator target).

### Problem

I'd encountered a recurring issue that I'd lightly touched on in [this comment](https://github.com/frankois944/spm4Kmp/issues/221#issuecomment-3610133158), in issue #221, but only recently did I find myself running into it more prevalently. I figured I'd likely exacerbated the issue by jumping into Xcode `26.3` so soon after its release, but I opted to do some digging.

What I found was that when building for `generic/platform=iOS Simulator`, some `CopyPackageResourcesTask` tasks fail with errors of the form:

```
A problem was found with the configuration of task ':root-project:module:SwiftPackageConfigAppleMapboxMapsShimCopyPackageResourcesIosSimulatorArm64' (type 'CopyPackageResourcesTask').
  - Type 'io.github.frankois944.spmForKmp.tasks.apple.copyPackageResources.CopyPackageResourcesTask' property 'builtDirectory' specifies directory '/Users/username/.../build/spmKmpPlugin/.../scratch/arm64 x86_64-apple-ios-simulator/release' which doesn't exist.
```

This blocks downstream builds even when the correct compiled artifacts are present.

### Root Cause

> [!NOTE]
> This is what I could ascertain in the time I had to approach this investigation, so hopefully it hits the mark, despite my time-constraints.

I found that `CopyPackageResourcesTask` was deriving the resources build directory from raw Xcode `ARCHS`. I was nudged in this direction based on information I found in [this loosely related issue](https://github.com/frankois944/spm4Kmp/issues/160), and more specifically, [the noted workaround](https://github.com/frankois944/spm4Kmp/issues/160#issuecomment-3224090872) in that issue conversation thread.

For Simulator builds, it appears that Xcode may provide multiple architectures in one string (`arm64 x86_64`), regardless of the project's Build Settings limiting the targeted architectures to `arm64` alone. This would then cause the plugin to look for a non-existent folder name (`arm64 x86_64-apple-ios-simulator`) while Swift package compilation outputs are target-specific (for example `arm64-apple-ios-simulator`).

### Changes

- Updated `copy-resources` task configuration to resolve `builtDirectory` from the compile target (`cinteropTarget.packageBuildDirName()`), not from raw `ARCHS` environment variable, originating from Xcode.
- Added a functional regression test called `copy resources task works when simulator ARCHS has multiple values` that aims to simulate the root cause (`ARCHS=arm64 x86_64`) and verify `copy-resources` task succeeds for `iosSimulatorArm64`, despite the multi-architecture configuration.

### Rationale.

## 📄 Motivation and Context

The compile task output path is target-derived, not “raw ARCHS”-derived. Using the same target-derived naming in `copy-resources` should keep producer/consumer paths consistent and avoid issues originating from Xcode architecture-list formatting

### Related Issues

- #221 
- #160 

## 🧪 How Has This Been Tested?

- Functional test coverage added for multi-arch simulator `ARCHS`.
- Reproduced downstream failure scenario and verified that the previous `CopyPackageResourcesTask` configuration error no longer occurs for simulator builds.

Importantly, this PR doesn't introduce behavioural changes for physical device builds, nor alter any existing `x86_64` Simulator support.

### Validation Environment

- Gradle `8.12.1`
- AGP `8.7.3` (per the version catalog)
- Kotlin `2.2.20` (per the note in the version catalog, indicating `2.2.20+` is required for Xcode `26+` support.
- Java `21.0.10` (JetBrains)

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.