### PR TITLE
Fix Multi-Target Builds Failing With Binary XCFramework Dependencies

### DIFF
--- a/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/MultiTargetBinaryPackageTest.kt
+++ b/plugin-build/plugin/src/functionalTest/kotlin/io/github/frankois944/spmForKmp/MultiTargetBinaryPackageTest.kt
@@ -1,0 +1,66 @@
+package io.github.frankois944.spmForKmp
+
+import com.autonomousapps.kit.GradleBuilder
+import com.autonomousapps.kit.truth.TestKitTruth.Companion.assertThat
+import io.github.frankois944.spmForKmp.config.AppleCompileTarget
+import io.github.frankois944.spmForKmp.fixture.KotlinSource
+import io.github.frankois944.spmForKmp.fixture.SmpKMPTestFixture
+import io.github.frankois944.spmForKmp.fixture.SwiftSource
+import io.github.frankois944.spmForKmp.utils.BaseTest
+import org.junit.jupiter.api.Test
+
+class MultiTargetBinaryPackageTest : BaseTest() {
+    @Test
+    fun `build with remote binary packages and multiple targets`() {
+        // Given
+        val fixture =
+            SmpKMPTestFixture
+                .builder()
+                .withBuildPath(testProjectDir.root.absolutePath)
+                .withTargets(
+                    AppleCompileTarget.iosSimulatorArm64,
+                    AppleCompileTarget.iosArm64,
+                ).withRawDependencies(
+                    KotlinSource.of(
+                        content =
+                            """
+                            remoteBinary(
+                                url = URI("https://spmforkmp.eu/DummyFrameworkV2.xcframework.zip"),
+                                checksum = "ce79ee72991d40620f156e407e47145ba3279cc15ebf20bb2560c7882d69e56e",
+                                packageName = "DummyFramework",
+                                exportToKotlin = true
+                            )
+                            remoteBinary(
+                                url = uri("https://github.com/wanliyunyan/LibXray/releases/download/25.8.3/LibXray.xcframework.zip"),
+                                packageName = "LibXray",
+                                exportToKotlin = true,
+                                checksum = "1f478c370bbe9cce12ed7f2f6101853a74c3a2220253dbaf5abcc446260c393d",
+                            )
+                            """.trimIndent(),
+                    ),
+                ).withKotlinSources(
+                    KotlinSource.of(
+                        imports = listOf("DummyFramework.DummyFrameworkVersionNumber"),
+                    ),
+                ).withSwiftSources(
+                    SwiftSource.of(
+                        content =
+                            """
+                            import Foundation
+                            import DummyFramework
+                            import LibXray
+                            @objc public class MySwiftClass: NSObject {
+                            }
+                            """.trimIndent(),
+                    ),
+                ).build()
+
+        val result =
+            GradleBuilder
+                .runner(fixture.gradleProject.rootDir, "build")
+                .build()
+
+        // Then
+        assertThat(result).task(":library:build").succeeded()
+    }
+}

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/SpmForKmpPlugin.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/SpmForKmpPlugin.kt
@@ -91,8 +91,10 @@ public abstract class SpmForKmpPlugin : Plugin<Project> {
                             "spmKmpPlugin",
                             swiftPackageEntry.internalName,
                         )
-                    val packageScratchDir = resolveAndCreateDir(spmWorkingDir, "scratch")
-                    val sharedCacheDir = swiftPackageEntry.sharedCachePath?.let { resolveAndCreateDir(File(it)) }
+                    val packageScratchBaseDir = resolveAndCreateDir(spmWorkingDir, "scratch")
+                    val sharedCacheDir =
+                        swiftPackageEntry.sharedCachePath?.let { resolveAndCreateDir(File(it)) }
+                            ?: resolveAndCreateDir(spmWorkingDir, "sharedCache")
                     val sharedConfigDir = swiftPackageEntry.sharedConfigPath?.let { resolveAndCreateDir(File(it)) }
                     val sharedSecurityDir = swiftPackageEntry.sharedSecurityPath?.let { resolveAndCreateDir(File(it)) }
                     val bridgeSourceDir =
@@ -120,7 +122,7 @@ public abstract class SpmForKmpPlugin : Plugin<Project> {
                         packageDirectoriesConfig =
                             PackageDirectoriesConfig(
                                 spmWorkingDir = spmWorkingDir,
-                                packageScratchDir = packageScratchDir,
+                                packageScratchBaseDir = packageScratchBaseDir,
                                 sharedCacheDir = sharedCacheDir,
                                 sharedConfigDir = sharedConfigDir,
                                 sharedSecurityDir = sharedSecurityDir,
@@ -221,12 +223,11 @@ public abstract class SpmForKmpPlugin : Plugin<Project> {
         }
     }
 
-    private fun mergeEntries(entries: Set<PackageRootDefinitionExtension>): Set<PackageRootDefinitionExtension> {
-        return entries
+    private fun mergeEntries(entries: Set<PackageRootDefinitionExtension>): Set<PackageRootDefinitionExtension> =
+        entries
             .groupBy { it.internalName }
             .values
             .map { groupedEntries ->
                 groupedEntries.firstOrNull { it.targetName == null } ?: groupedEntries.first()
             }.toSet()
-    }
 }

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/config/PackageDirectoriesConfig.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/config/PackageDirectoriesConfig.kt
@@ -4,9 +4,11 @@ import java.io.File
 
 internal data class PackageDirectoriesConfig(
     val spmWorkingDir: File,
-    val packageScratchDir: File,
+    val packageScratchBaseDir: File,
     val sharedCacheDir: File?,
     val sharedConfigDir: File?,
     val sharedSecurityDir: File?,
     val bridgeSourceDir: File,
-)
+) {
+    fun targetScratchDir(target: AppleCompileTarget): File = packageScratchBaseDir.resolve(target.triple(""))
+}

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
@@ -101,9 +101,11 @@ internal fun Project.configAppleTargets(
     val buildMode = getBuildMode(swiftPackageEntry)
     allTargets.forEachIndexed { index, cinteropTarget ->
         logger.debug("SETUP {}", cinteropTarget)
+        val targetScratchDir = packageDirectoriesConfig.targetScratchDir(cinteropTarget)
+        targetScratchDir.mkdirs()
         val targetBuildDir =
             getTargetBuildDirectory(
-                packageScratchDir = packageDirectoriesConfig.packageScratchDir,
+                packageScratchDir = targetScratchDir,
                 cinteropTarget = cinteropTarget,
                 buildMode = buildMode,
             )
@@ -117,6 +119,7 @@ internal fun Project.configAppleTargets(
                     packageDirectoriesConfig = packageDirectoriesConfig,
                     buildMode = buildMode,
                     cinteropTarget = cinteropTarget,
+                    targetScratchDir = targetScratchDir,
                 )
             }
 
@@ -130,7 +133,7 @@ internal fun Project.configAppleTargets(
                     swiftPackageEntry = swiftPackageEntry,
                     packageDirectoriesConfig = packageDirectoriesConfig,
                     targetBuildDir = targetBuildDir,
-                    isFirstTarget = index == 0,
+                    targetScratchDir = targetScratchDir,
                 )
             }
 
@@ -149,6 +152,7 @@ internal fun Project.configAppleTargets(
                     swiftPackageEntry = swiftPackageEntry,
                     packageDirectoriesConfig = packageDirectoriesConfig,
                     packageDependencies = packageDependencies,
+                    targetScratchDir = targetScratchDir,
                 )
             }
 

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/compileSwiftPackage/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/compileSwiftPackage/ConfigureTask.kt
@@ -15,13 +15,13 @@ internal fun CompileSwiftPackageTask.configureTask(
     swiftPackageEntry: PackageRootDefinitionExtension,
     packageDirectoriesConfig: PackageDirectoriesConfig,
     targetBuildDir: File,
-    isFirstTarget: Boolean,
+    targetScratchDir: File,
 ) {
     this.cinteropTarget.set(cinteropTarget)
     this.debugMode.set(swiftPackageEntry.debug)
     this.packageSwift.set(packageDirectoriesConfig.spmWorkingDir.resolve(SWIFT_PACKAGE_NAME))
     this.workingDir.set(packageDirectoriesConfig.spmWorkingDir.absolutePath)
-    this.packageScratchDir.set(packageDirectoriesConfig.packageScratchDir.absolutePath)
+    this.packageScratchDir.set(targetScratchDir.absolutePath)
     this.bridgeSourceDir.set(packageDirectoriesConfig.bridgeSourceDir)
     this.osVersion.set(computeOsVersion(cinteropTarget, swiftPackageEntry))
     this.sharedCacheDir.set(packageDirectoriesConfig.sharedCacheDir?.absolutePath)
@@ -41,12 +41,10 @@ internal fun CompileSwiftPackageTask.configureTask(
     this.packageResolveFile.set(packageDirectoriesConfig.spmWorkingDir.resolve(SWIFT_PACKAGE_RESOLVE_NAME))
     this.generatedDirs.set(
         buildList {
-            if (isFirstTarget) {
-                add(packageDirectoriesConfig.packageScratchDir.resolve("artifacts"))
-                add(packageDirectoriesConfig.packageScratchDir.resolve("plugins"))
-                add(packageDirectoriesConfig.packageScratchDir.resolve("registry"))
-                add(packageDirectoriesConfig.packageScratchDir.resolve("checkouts"))
-            }
+            add(targetScratchDir.resolve("artifacts"))
+            add(targetScratchDir.resolve("plugins"))
+            add(targetScratchDir.resolve("registry"))
+            add(targetScratchDir.resolve("checkouts"))
             add(targetBuildDir)
         },
     )

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/copyPackageResources/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/copyPackageResources/ConfigureTask.kt
@@ -5,11 +5,13 @@ import io.github.frankois944.spmForKmp.config.AppleCompileTarget
 import io.github.frankois944.spmForKmp.config.PackageDirectoriesConfig
 import io.github.frankois944.spmForKmp.tasks.utils.isTraceEnabled
 import org.gradle.api.Project
+import java.io.File
 
 internal fun CopyPackageResourcesTask.configureTask(
     packageDirectoriesConfig: PackageDirectoriesConfig,
     buildMode: String,
     cinteropTarget: AppleCompileTarget,
+    targetScratchDir: File,
 ) {
     val buildProductDir: String? =
         project.propertyOrNull("io.github.frankois944.spmForKmp.BUILT_PRODUCTS_DIR") as? String
@@ -46,7 +48,7 @@ internal fun CopyPackageResourcesTask.configureTask(
     }
 
     this.builtDirectory.set(
-        packageDirectoriesConfig.packageScratchDir
+        targetScratchDir
             .resolve(cinteropTarget.packageBuildDirName())
             .resolve(buildMode),
     )

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateCInteropDefinition/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateCInteropDefinition/ConfigureTask.kt
@@ -17,6 +17,7 @@ internal fun GenerateCInteropDefinitionTask.configureTask(
     swiftPackageEntry: PackageRootDefinitionExtension,
     packageDirectoriesConfig: PackageDirectoriesConfig,
     packageDependencies: List<SwiftDependency>,
+    targetScratchDir: File,
 ) {
     this.compiledBinary.set(
         targetBuildDir
@@ -31,7 +32,7 @@ internal fun GenerateCInteropDefinitionTask.configureTask(
         computeOsVersion(cinteropTarget, swiftPackageEntry),
     )
     this.manifestFile.set(packageDirectoriesConfig.spmWorkingDir.resolve(SWIFT_PACKAGE_NAME))
-    this.scratchDir.set(packageDirectoriesConfig.packageScratchDir.absolutePath)
+    this.scratchDir.set(targetScratchDir.absolutePath)
     this.packageDependencyPrefix.set(swiftPackageEntry.packageDependencyPrefix)
     this.compilerOpts.set(swiftPackageEntry.compilerOpts)
     this.linkerOpts.set(swiftPackageEntry.linkerOpts)

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateExportableManifest/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateExportableManifest/ConfigureTask.kt
@@ -33,7 +33,7 @@ internal fun GenerateExportableManifestTask.configureTask(
     this.exportedDirectory.set(exportedManifestDirectory)
     this.compiledTargetDir.set(
         getTargetBuildDirectory(
-            packageScratchDir = packageDirectoriesConfig.packageScratchDir,
+            packageScratchDir = packageDirectoriesConfig.targetScratchDir(targets.first()),
             cinteropTarget = targets.first(),
             buildMode = getBuildMode(swiftPackageEntry),
         ).absolutePath,

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/utils/CheckSum.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/utils/CheckSum.kt
@@ -21,7 +21,7 @@ internal object Hashing {
 
         md5Digest.update(config.bridgeSourceDir.path.toByteArray())
         md5Digest.update(config.spmWorkingDir.path.toByteArray())
-        md5Digest.update(config.packageScratchDir.path.toByteArray())
+        md5Digest.update(config.packageScratchBaseDir.path.toByteArray())
         config.sharedCacheDir?.path?.let {
             md5Digest.update(it.toByteArray())
         }


### PR DESCRIPTION
## 🚀 Description

Replace the shared SPM scratch directory with per-target scratch directories, keyed by the target triple (`build/spmKmpPlugin/<pkg>/scratch/<triple>/`). Each target now resolves and builds in its own isolated scratch directory, eliminating cross-target interference when building binary XCFramework dependencies.

Additionally, `sharedCacheDir` now auto-defaults to `spmWorkingDir/sharedCache/` when the user hasn't set one, ensuring SPM's package cache is shared across targets to avoid duplicate downloads. _(I'd initially tested with full isolation, but found it unnecessary and wasteful to duplicate the cache in its entirety)_

Here are some specifics around the changes (I tried to keep the number of touched files as small as possible, without compromising the quality of the fix):

- `PackageDirectoriesConfig`: Renamed `packageScratchDir` to `packageScratchBaseDir` and added `targetScratchDir(target)` helper.
- `SpmForKmpPlugin`: Renamed field, auto-default `sharedCacheDir`.
- `ConfigAppleTargets`: Computes per-target scratch dir, passes it to all task configurators.
- `compileSwiftPackage/ConfigureTask`: Removed `isFirstTarget` guard on `@OutputDirectories`. Each target now declares its own full output set.
- `copyPackageResources/ConfigureTask`: Uses per-target scratch dir.
- `generateCInteropDefinition/ConfigureTask`: Uses per-target scratch dir.
- `generateExportableManifest/ConfigureTask`: Uses `targetScratchDir(targets.first())`.
- `CheckSum`: Renamed field.

## 📄 Motivation and Context

When multiple Apple targets are configured (e.g. `iosSimulatorArm64` and `iosArm64`), they share a single SPM scratch directory. Each target's `swift build` invocation overwrites the previous target's resolved artifacts. For binary XCFramework dependencies, the second target fails because SPM can no longer find the binary resolved by the first target's build.

With any luck, these changes should resolve the following issues:

- #294
- #298
- #234

## 🧪 How Has This Been Tested?

I've added a `MultiTargetBinaryPackageTest` functional test that builds with `iosSimulatorArm64` and `iosArm64` targets, using two remote binary XCFramework dependencies (`DummyFramework`, `LibXray`) as this accurately models the exact scenario that fails without this fix.

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.