### PR TITLE
Move kotlin requirement version to 2.2.20

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4'
+          xcode-version: '26.0'
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 detekt = "1.23.8"
 # increase > 2.2.20 for xcode > 26
-kotlin = "2.1.21"
+kotlin = "2.2.20"
 ktlintGradle = "14.2.0"
 pluginPublish = "2.1.1"
 versionCheck = "0.53.0"


### PR DESCRIPTION
[Appstore requires now xcode 26 as minimal SDK version](https://developer.apple.com/news/upcoming-requirements/?id=02032026a), it's safe to move the minimal kotlin version to 2.2.20