### PR TITLE
Make resource more flexible

### DIFF
--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -79,12 +79,19 @@ val aView = MySwiftBridge().exportedView() as UIView
 
 ---
 
-## Bundle Resources (since v1.7.1)
+## Bundle Resources (since v1.9.0)
 
 To bundle resources (images, fonts, data files, etc.) alongside your bridge:
 
-1. Create a `Resources` folder inside your bridge directory
-2. Place your files there (e.g. `bridgeString.txt`)
+1. Choose a resource type and create the corresponding folder:
+
+| Type | Folder Name | Documentation |
+|------|-------------|---|
+| **Process** (Recommended) | `Resources-process` | [Process](https://developer.apple.com/documentation/packagedescription/resource/process(_:localization:)) |
+| **Copy** | `Resources-copy` | [Copy](https://developer.apple.com/documentation/packagedescription/resource/copy(_:)) |
+| **Embed** | `Resources-embed` | [Embed](https://developer.apple.com/documentation/packagedescription/resource/embedincode(_:)) |
+
+2. Place your files in the chosen folder (e.g. `bridgeString.txt`)
 3. Access them from Swift using `Bundle.module`:
 
 ```swift

--- a/example/src/iosTest/kotlin/com/example/IosTest.kt
+++ b/example/src/iosTest/kotlin/com/example/IosTest.kt
@@ -54,7 +54,9 @@ class IosTest {
 
     @Test
     fun getFileContentFromBridgeTest() {
-        assertEquals("My content\n", TestClass().localFile())
+        assertEquals("My embed content\n", TestClass.embedFile())
+        assertEquals("My process content\n", TestClass.localFile())
+        assertEquals("My copy content\n", TestClass.copyFile())
     }
 
     @Test

--- a/example/src/iosTest/kotlin/com/example/IosTest.kt
+++ b/example/src/iosTest/kotlin/com/example/IosTest.kt
@@ -56,6 +56,7 @@ class IosTest {
     fun getFileContentFromBridgeTest() {
         assertEquals("My embed content\n", TestClass.embedFile())
         assertEquals("My process content\n", TestClass.localFile())
+        assertEquals("My process content\n", TestClass.localFile2())
         assertEquals("My copy content\n", TestClass.copyFile())
     }
 

--- a/example/src/swift/nativeIosShared/Resources-copy/bridgeString-3.txt
+++ b/example/src/swift/nativeIosShared/Resources-copy/bridgeString-3.txt
@@ -1,0 +1,1 @@
+My copy content

--- a/example/src/swift/nativeIosShared/Resources-embed/bridgeString-2.txt
+++ b/example/src/swift/nativeIosShared/Resources-embed/bridgeString-2.txt
@@ -1,0 +1,1 @@
+My embed content

--- a/example/src/swift/nativeIosShared/Resources-process/bridgeString.txt
+++ b/example/src/swift/nativeIosShared/Resources-process/bridgeString.txt
@@ -1,0 +1,1 @@
+My process content

--- a/example/src/swift/nativeIosShared/Resources/bridgeString-4.txt
+++ b/example/src/swift/nativeIosShared/Resources/bridgeString-4.txt
@@ -1,0 +1,1 @@
+My copy content

--- a/example/src/swift/nativeIosShared/Resources/bridgeString.txt
+++ b/example/src/swift/nativeIosShared/Resources/bridgeString.txt
@@ -1,1 +1,0 @@
-My content

--- a/example/src/swift/nativeIosShared/SpmForSwiftSource.swift
+++ b/example/src/swift/nativeIosShared/SpmForSwiftSource.swift
@@ -45,10 +45,25 @@ import registrydummy
         hev_socks5_tunnel_quit()
     }
 
-    public func localFile() -> String {
-        // Explicit use of Foundation.Bundle via alias to avoid CryptoSwift's Bundle shadowing on older Xcode
+    public static func localFile() -> String {
         guard let url = Bundle.module.url(forResource: "bridgeString", withExtension: "txt") else {
             assertionFailure("bridgeString.txt not found in Bundle.module")
+            return ""
+        }
+        return (try? String(contentsOf: url)) ?? ""
+    }
+
+    public static func copyFile() -> String {
+        guard let url = Bundle.module.url(forResource: "bridgeString-3", withExtension: "txt") else {
+            assertionFailure("bridgeString-3.txt not found in Bundle.module")
+            return ""
+        }
+        return (try? String(contentsOf: url)) ?? ""
+    }
+
+    public static func embedFile() -> String {
+        guard let url = Bundle.module.url(forResource: "bridgeString-2", withExtension: "txt") else {
+            assertionFailure("bridgeString-2.txt not found in Bundle.module")
             return ""
         }
         return (try? String(contentsOf: url)) ?? ""

--- a/example/src/swift/nativeIosShared/SpmForSwiftSource.swift
+++ b/example/src/swift/nativeIosShared/SpmForSwiftSource.swift
@@ -53,6 +53,14 @@ import registrydummy
         return (try? String(contentsOf: url)) ?? ""
     }
 
+    public static func localFile2() -> String {
+        guard let url = Bundle.module.url(forResource: "bridgeString-4", withExtension: "txt") else {
+            assertionFailure("bridgeString.txt not found in Bundle.module")
+            return ""
+        }
+        return (try? String(contentsOf: url)) ?? ""
+    }
+
     public static func copyFile() -> String {
         guard let url = Bundle.module.url(forResource: "bridgeString-3", withExtension: "txt") else {
             assertionFailure("bridgeString-3.txt not found in Bundle.module")

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/manifest/GenerateManifest.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/manifest/GenerateManifest.kt
@@ -100,7 +100,7 @@ private fun getResourceSettings(paths: ResourcesPaths?): String? =
     } else {
         buildString {
             append("resources: [")
-            val paths =
+            val builtPaths =
                 buildList {
                     paths.processPath?.let {
                         add(".process(\"$it\")")
@@ -112,7 +112,7 @@ private fun getResourceSettings(paths: ResourcesPaths?): String? =
                         add(".embedInCode(\"$it\")")
                     }
                 }.joinToString(",")
-            append(paths)
+            append(builtPaths)
             append("]")
         }
     }

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/manifest/GenerateManifest.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/manifest/GenerateManifest.kt
@@ -37,7 +37,7 @@ internal fun generateManifest(parameters: TemplateParameters): String {
             swiftBuildDir = parameters.generatedPackageDirectory,
             settings = parameters.targetSettings,
         ).takeIf { it.isNotEmpty() }
-
+    val getResourceSetting = getResourceSettings(parameters.resourcesPaths)
     val name = parameters.exportedPackage?.name ?: parameters.productName
     val type =
         parameters.exportedPackage?.isStatic?.let {
@@ -82,8 +82,8 @@ let package = Package(
     }
             ],
             path: "Sources"
+            ${getResourceSetting?.let { ",$it" }.orEmpty()}
             ${getTargetSetting?.let { ",$it" }.orEmpty()}
-            ${getResourceSettings(parameters.resourcesPaths)}
         )
         $binaryDependencies
     ]
@@ -91,14 +91,29 @@ let package = Package(
         """
 }
 
-private fun getResourceSettings(paths: List<String>?): String =
-    if (paths.isNullOrEmpty()) {
-        ""
+private fun getResourceSettings(paths: ResourcesPaths?): String? =
+    if (paths?.embedPath.isNullOrEmpty() &&
+        paths?.copiedPath.isNullOrEmpty() &&
+        paths?.processPath.isNullOrEmpty()
+    ) {
+        null
     } else {
         buildString {
-            append(", resources: [")
-            append(paths.joinToString(",") { ".process(\"$it\")" })
-            append("],")
+            append("resources: [")
+            val paths =
+                buildList {
+                    paths.processPath?.let {
+                        add(".process(\"$it\")")
+                    }
+                    paths.copiedPath?.let {
+                        add(".copy(\"$it\")")
+                    }
+                    paths.embedPath?.let {
+                        add(".embedInCode(\"$it\")")
+                    }
+                }.joinToString(",")
+            append(paths)
+            append("]")
         }
     }
 

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/manifest/TemplateParameters.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/manifest/TemplateParameters.kt
@@ -11,7 +11,11 @@ internal data class ResourcesPaths(
     val copiedPath: String?,
     val processPath: String?,
     val embedPath: String?,
-) : Serializable
+) : Serializable {
+    internal companion object {
+        private const val serialVersionUID: Long = 1
+    }
+}
 
 internal data class TemplateParameters(
     val forExportedPackage: Boolean,

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/manifest/TemplateParameters.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/manifest/TemplateParameters.kt
@@ -4,7 +4,14 @@ import io.github.frankois944.spmForKmp.config.ModuleConfig
 import io.github.frankois944.spmForKmp.definition.SwiftDependency
 import io.github.frankois944.spmForKmp.definition.exported.ExportedPackage
 import io.github.frankois944.spmForKmp.definition.packageSetting.BridgeSettings
+import java.io.Serializable
 import java.nio.file.Path
+
+internal data class ResourcesPaths(
+    val copiedPath: String?,
+    val processPath: String?,
+    val embedPath: String?,
+) : Serializable
 
 internal data class TemplateParameters(
     val forExportedPackage: Boolean,
@@ -19,5 +26,5 @@ internal data class TemplateParameters(
     val targetSettings: BridgeSettings?,
     val exportedPackage: ExportedPackage?,
     val onlyDeps: List<ModuleConfig> = emptyList(),
-    val resourcesPaths: List<String>? = null,
+    val resourcesPaths: ResourcesPaths?,
 )

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateExportableManifest/GenerateExportableManifestTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateExportableManifest/GenerateExportableManifestTask.kt
@@ -149,6 +149,7 @@ internal abstract class GenerateExportableManifestTask : DefaultTask() {
                                     targetSettings = null,
                                     exportedPackage = exportedPackage.get(),
                                     onlyDeps = requiredDependencies,
+                                    resourcesPaths = null,
                                 ),
                         )
                     manifestFile.writeText(manifest)

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateManifest/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateManifest/ConfigureTask.kt
@@ -10,13 +10,17 @@ import io.github.frankois944.spmForKmp.manifest.ResourcesPaths
 import io.github.frankois944.spmForKmp.tasks.utils.isTraceEnabled
 
 private fun buildResourcesPath(packageDirectoriesConfig: PackageDirectoriesConfig): ResourcesPaths {
-    val copyDir = packageDirectoriesConfig.bridgeSourceDir.resolve("Resources-copy")
-    val processDir = packageDirectoriesConfig.bridgeSourceDir.resolve("Resources-process")
-    val embedDir = packageDirectoriesConfig.bridgeSourceDir.resolve("Resources-embed")
+    val base = packageDirectoriesConfig.bridgeSourceDir
+    fun java.io.File.relativePathIfExists() = takeIf { it.exists() }?.relativeToOrSelf(base)?.path
+
+    val processDir =
+        listOf(base.resolve("Resources-process"), base.resolve("Resources"))
+            .firstOrNull { it.exists() }
+
     return ResourcesPaths(
-        copiedPath = copyDir.takeIf { it.exists() }?.relativeToOrSelf(packageDirectoriesConfig.bridgeSourceDir)?.path,
-        processPath = processDir.takeIf { it.exists() }?.relativeToOrSelf(packageDirectoriesConfig.bridgeSourceDir)?.path,
-        embedPath = embedDir.takeIf { it.exists() }?.relativeToOrSelf(packageDirectoriesConfig.bridgeSourceDir)?.path,
+        copiedPath = base.resolve("Resources-copy").relativePathIfExists(),
+        processPath = processDir?.relativeToOrSelf(base)?.path,
+        embedPath = base.resolve("Resources-embed").relativePathIfExists(),
     )
 }
 

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateManifest/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateManifest/ConfigureTask.kt
@@ -6,7 +6,19 @@ import io.github.frankois944.spmForKmp.config.PackageDirectoriesConfig
 import io.github.frankois944.spmForKmp.definition.PackageRootDefinitionExtension
 import io.github.frankois944.spmForKmp.definition.SwiftDependency
 import io.github.frankois944.spmForKmp.definition.packageSetting.BridgeSettings
+import io.github.frankois944.spmForKmp.manifest.ResourcesPaths
 import io.github.frankois944.spmForKmp.tasks.utils.isTraceEnabled
+
+private fun buildResourcesPath(packageDirectoriesConfig: PackageDirectoriesConfig): ResourcesPaths {
+    val copyDir = packageDirectoriesConfig.bridgeSourceDir.resolve("Resources-copy")
+    val processDir = packageDirectoriesConfig.bridgeSourceDir.resolve("Resources-process")
+    val embedDir = packageDirectoriesConfig.bridgeSourceDir.resolve("Resources-embed")
+    return ResourcesPaths(
+        copiedPath = copyDir.takeIf { it.exists() }?.relativeToOrSelf(packageDirectoriesConfig.bridgeSourceDir)?.path,
+        processPath = processDir.takeIf { it.exists() }?.relativeToOrSelf(packageDirectoriesConfig.bridgeSourceDir)?.path,
+        embedPath = embedDir.takeIf { it.exists() }?.relativeToOrSelf(packageDirectoriesConfig.bridgeSourceDir)?.path,
+    )
+}
 
 internal fun GenerateManifestTask.configureTask(
     swiftPackageEntry: PackageRootDefinitionExtension,
@@ -24,7 +36,7 @@ internal fun GenerateManifestTask.configureTask(
     this.targetSettings.set(swiftPackageEntry.bridgeSettings as BridgeSettings)
     this.swiftBinPath.set(swiftPackageEntry.swiftBinPath)
     this.traceEnabled.set(project.isTraceEnabled)
-    this.hasResourceFolder.set(packageDirectoriesConfig.bridgeSourceDir.resolve("Resources").exists())
+    this.resourcesPaths.set(buildResourcesPath(packageDirectoriesConfig))
     this.storedTraceFile.set(
         project.projectDir
             .resolve(SPM_TRACE_NAME)

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateManifest/GenerateManifestTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateManifest/GenerateManifestTask.kt
@@ -10,7 +10,12 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 import org.jetbrains.kotlin.konan.target.HostManager
 import javax.inject.Inject

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateManifest/GenerateManifestTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateManifest/GenerateManifestTask.kt
@@ -2,6 +2,7 @@ package io.github.frankois944.spmForKmp.tasks.apple.generateManifest
 
 import io.github.frankois944.spmForKmp.definition.SwiftDependency
 import io.github.frankois944.spmForKmp.definition.packageSetting.BridgeSettings
+import io.github.frankois944.spmForKmp.manifest.ResourcesPaths
 import io.github.frankois944.spmForKmp.manifest.TemplateParameters
 import io.github.frankois944.spmForKmp.manifest.generateManifest
 import io.github.frankois944.spmForKmp.tasks.utils.TaskTracer
@@ -9,12 +10,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
 import org.gradle.process.ExecOperations
 import org.jetbrains.kotlin.konan.target.HostManager
 import javax.inject.Inject
@@ -25,7 +21,7 @@ internal abstract class GenerateManifestTask : DefaultTask() {
     abstract val packageDependencies: ListProperty<SwiftDependency>
 
     @get:Input
-    abstract val hasResourceFolder: Property<Boolean>
+    abstract val resourcesPaths: Property<ResourcesPaths>
 
     @get:Input
     abstract val packageName: Property<String>
@@ -109,8 +105,7 @@ internal abstract class GenerateManifestTask : DefaultTask() {
                                 toolsVersion = toolsVersion.get(),
                                 targetSettings = targetSettings.get(),
                                 exportedPackage = null,
-                                resourcesPaths =
-                                    getResourcePaths(),
+                                resourcesPaths = resourcesPaths.get(),
                             ),
                     )
                 manifestFile.get().asFile.writeText(manifest)
@@ -118,11 +113,4 @@ internal abstract class GenerateManifestTask : DefaultTask() {
         }
         tracer.writeHtmlReport()
     }
-
-    private fun getResourcePaths(): List<String>? =
-        if (hasResourceFolder.get()) {
-            listOf("Resources")
-        } else {
-            null
-        }
 }


### PR DESCRIPTION
- Fix issue on SPM manifest structure

- Add the possibility to use the capability of SPM to handle resources.

Depending on the name of the directory inside the bridge
- [Resources-copy](https://developer.apple.com/documentation/packagedescription/resource/copy(_:))
- [Resources-process](https://developer.apple.com/documentation/packagedescription/resource/process(_:localization:))
- [Resources-embed](https://developer.apple.com/documentation/packagedescription/resource/embedincode(_:))

The existing `Resources` has the same behavior as `Resources-process` but only one is possible
