### PR TITLE
Update task dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
@@ -8,6 +9,7 @@ plugins {
     alias(libs.plugins.ktlint)
     alias(libs.plugins.versionCheck)
     alias(libs.plugins.publish) apply false
+    id("com.dorongold.task-tree").version("4.0.1")
 }
 
 subprojects {

--- a/example/gradle.properties
+++ b/example/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.jvmargs=-Xmx8G -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx8G"
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx8G -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx8G"
 org.gradle.parallel=true
 
 kotlin.code.style=official

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
@@ -130,7 +130,6 @@ internal fun Project.configAppleTargets(
                     swiftPackageEntry = swiftPackageEntry,
                     packageDirectoriesConfig = packageDirectoriesConfig,
                     targetBuildDir = targetBuildDir,
-                    isFirstTarget = index == 0,
                 )
             }
 

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
@@ -98,6 +98,10 @@ internal fun Project.configAppleTargets(
             )
         }
 
+    exportedManifestTask.configure {
+        it.dependsOn(manifestTask)
+    }
+
     val buildMode = getBuildMode(swiftPackageEntry)
     allTargets.forEachIndexed { index, cinteropTarget ->
         logger.debug("SETUP {}", cinteropTarget)
@@ -130,7 +134,6 @@ internal fun Project.configAppleTargets(
                     swiftPackageEntry = swiftPackageEntry,
                     packageDirectoriesConfig = packageDirectoriesConfig,
                     targetBuildDir = targetBuildDir,
-                    isFirstTarget = index == 0,
                 )
             }
 
@@ -206,9 +209,6 @@ internal fun Project.configAppleTargets(
         }
         definitionTask.configure {
             it.dependsOn(copyPackageResourcesTask)
-        }
-        exportedManifestTask.configure {
-            it.dependsOn(definitionTask)
         }
 
         // Keep a handle to the "root" for this target

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/ConfigAppleTargets.kt
@@ -98,10 +98,6 @@ internal fun Project.configAppleTargets(
             )
         }
 
-    exportedManifestTask.configure {
-        it.dependsOn(manifestTask)
-    }
-
     val buildMode = getBuildMode(swiftPackageEntry)
     allTargets.forEachIndexed { index, cinteropTarget ->
         logger.debug("SETUP {}", cinteropTarget)
@@ -134,8 +130,15 @@ internal fun Project.configAppleTargets(
                     swiftPackageEntry = swiftPackageEntry,
                     packageDirectoriesConfig = packageDirectoriesConfig,
                     targetBuildDir = targetBuildDir,
+                    isFirstTarget = index == 0,
                 )
             }
+
+        // mustRunAfter (not dependsOn) so we get correct ordering when both targets are in the
+        // build graph, without forcing unrelated targets to compile in a single-target build.
+        exportedManifestTask.configure {
+            it.mustRunAfter(compileTask)
+        }
 
         val definitionTask =
             tasks.register(

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/compileSwiftPackage/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/compileSwiftPackage/ConfigureTask.kt
@@ -15,7 +15,6 @@ internal fun CompileSwiftPackageTask.configureTask(
     swiftPackageEntry: PackageRootDefinitionExtension,
     packageDirectoriesConfig: PackageDirectoriesConfig,
     targetBuildDir: File,
-    isFirstTarget: Boolean,
 ) {
     this.cinteropTarget.set(cinteropTarget)
     this.debugMode.set(swiftPackageEntry.debug)
@@ -42,12 +41,6 @@ internal fun CompileSwiftPackageTask.configureTask(
     this.generatedDirs.set(
         buildList {
             add(targetBuildDir)
-            if (isFirstTarget) {
-                add(packageDirectoriesConfig.packageScratchDir.resolve("artifacts"))
-                add(packageDirectoriesConfig.packageScratchDir.resolve("plugins"))
-                add(packageDirectoriesConfig.packageScratchDir.resolve("registry"))
-                add(packageDirectoriesConfig.packageScratchDir.resolve("checkouts"))
-            }
         },
     )
 }

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/compileSwiftPackage/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/compileSwiftPackage/ConfigureTask.kt
@@ -15,7 +15,6 @@ internal fun CompileSwiftPackageTask.configureTask(
     swiftPackageEntry: PackageRootDefinitionExtension,
     packageDirectoriesConfig: PackageDirectoriesConfig,
     targetBuildDir: File,
-    isFirstTarget: Boolean,
 ) {
     this.cinteropTarget.set(cinteropTarget)
     this.debugMode.set(swiftPackageEntry.debug)
@@ -41,12 +40,6 @@ internal fun CompileSwiftPackageTask.configureTask(
     this.packageResolveFile.set(packageDirectoriesConfig.spmWorkingDir.resolve(SWIFT_PACKAGE_RESOLVE_NAME))
     this.generatedDirs.set(
         buildList {
-            if (isFirstTarget) {
-                add(packageDirectoriesConfig.packageScratchDir.resolve("artifacts"))
-                add(packageDirectoriesConfig.packageScratchDir.resolve("plugins"))
-                add(packageDirectoriesConfig.packageScratchDir.resolve("registry"))
-                add(packageDirectoriesConfig.packageScratchDir.resolve("checkouts"))
-            }
             add(targetBuildDir)
         },
     )

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/compileSwiftPackage/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/compileSwiftPackage/ConfigureTask.kt
@@ -15,6 +15,7 @@ internal fun CompileSwiftPackageTask.configureTask(
     swiftPackageEntry: PackageRootDefinitionExtension,
     packageDirectoriesConfig: PackageDirectoriesConfig,
     targetBuildDir: File,
+    isFirstTarget: Boolean,
 ) {
     this.cinteropTarget.set(cinteropTarget)
     this.debugMode.set(swiftPackageEntry.debug)
@@ -41,6 +42,12 @@ internal fun CompileSwiftPackageTask.configureTask(
     this.generatedDirs.set(
         buildList {
             add(targetBuildDir)
+            if (isFirstTarget) {
+                add(packageDirectoriesConfig.packageScratchDir.resolve("artifacts"))
+                add(packageDirectoriesConfig.packageScratchDir.resolve("plugins"))
+                add(packageDirectoriesConfig.packageScratchDir.resolve("registry"))
+                add(packageDirectoriesConfig.packageScratchDir.resolve("checkouts"))
+            }
         },
     )
 }

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateExportableManifest/ConfigureTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateExportableManifest/ConfigureTask.kt
@@ -31,12 +31,14 @@ internal fun GenerateExportableManifestTask.configureTask(
             .asFile
             .resolve(productName)
     this.exportedDirectory.set(exportedManifestDirectory)
-    this.compiledTargetDir.set(
-        getTargetBuildDirectory(
-            packageScratchDir = packageDirectoriesConfig.packageScratchDir,
-            cinteropTarget = targets.first(),
-            buildMode = getBuildMode(swiftPackageEntry),
-        ).absolutePath,
+    this.compiledTargetDirs.set(
+        targets.map { target ->
+            getTargetBuildDirectory(
+                packageScratchDir = packageDirectoriesConfig.packageScratchDir,
+                cinteropTarget = target,
+                buildMode = getBuildMode(swiftPackageEntry),
+            ).absolutePath
+        },
     )
     this.includeProduct.set(swiftPackageEntry.exportedPackageSettings.includeProduct)
     this.hideLocalPackageMessage.set(project.hideLocalPackageMessage())

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateExportableManifest/GenerateExportableManifestTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateExportableManifest/GenerateExportableManifestTask.kt
@@ -55,7 +55,7 @@ internal abstract class GenerateExportableManifestTask : DefaultTask() {
     abstract val exportedPackage: Property<ExportedPackage>
 
     @get:Input
-    abstract val compiledTargetDir: Property<String>
+    abstract val compiledTargetDirs: ListProperty<String>
 
     @get:Input
     abstract val includeProduct: ListProperty<String>
@@ -223,32 +223,39 @@ internal abstract class GenerateExportableManifestTask : DefaultTask() {
             } else if (moduleToInclude.contains(module.name.lowercase())) {
                 requireDependencies.add(module)
             } else {
-                File(compiledTargetDir.get())
-                    .listFiles { it.extension == "framework" }
-                    .firstOrNull {
-                        logger.debug("checking module {} at {}", module.name, it)
-                        it.nameWithoutExtension.equals(module.name, ignoreCase = true)
-                    }?.let { moduleLocation ->
-                        // if the module is inside the compiled build directory
-                        var plist = moduleLocation.resolve("Info.plist")
-                        if (!plist.exists()) {
-                            logger.debug(
-                                "The plist is not at the root of the framework, try the Resource folder instead",
-                            )
-                            plist = moduleLocation.resolve("Resources").resolve("Info.plist")
+                // Search all compiled target dirs; the first one that has the framework wins.
+                val moduleLocation =
+                    compiledTargetDirs
+                        .get()
+                        .asSequence()
+                        .flatMap { dir ->
+                            File(dir).listFiles { it.extension == "framework" }?.asSequence()
+                                ?: emptySequence()
+                        }.firstOrNull {
+                            logger.debug("checking module {} at {}", module.name, it)
+                            it.nameWithoutExtension.equals(module.name, ignoreCase = true)
                         }
-                        logger.debug("Looking inside the Info.plist {}", plist)
-                        val libraryName = getPlistValue(plist, "CFBundleExecutable")
-                        logger.debug("Found libraryName {}", libraryName)
-                        val binaryFile = moduleLocation.resolve(libraryName)
-                        if (!execOps.isDynamicLibrary(binaryFile, logger)) {
-                            logger.debug(
-                                "Found static framework {} add it to the require dependency list",
-                                moduleLocation,
-                            )
-                            requireDependencies.add(module)
-                        }
+                if (moduleLocation != null) {
+                    // if the module is inside a compiled build directory
+                    var plist = moduleLocation.resolve("Info.plist")
+                    if (!plist.exists()) {
+                        logger.debug(
+                            "The plist is not at the root of the framework, try the Resource folder instead",
+                        )
+                        plist = moduleLocation.resolve("Resources").resolve("Info.plist")
                     }
+                    logger.debug("Looking inside the Info.plist {}", plist)
+                    val libraryName = getPlistValue(plist, "CFBundleExecutable")
+                    logger.debug("Found libraryName {}", libraryName)
+                    val binaryFile = moduleLocation.resolve(libraryName)
+                    if (!execOps.isDynamicLibrary(binaryFile, logger)) {
+                        logger.debug(
+                            "Found static framework {} add it to the require dependency list",
+                            moduleLocation,
+                        )
+                        requireDependencies.add(module)
+                    }
+                }
             }
         }
         return requireDependencies

--- a/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateExportableManifest/GenerateExportableManifestTask.kt
+++ b/plugin-build/plugin/src/main/java/io/github/frankois944/spmForKmp/tasks/apple/generateExportableManifest/GenerateExportableManifestTask.kt
@@ -229,6 +229,7 @@ internal abstract class GenerateExportableManifestTask : DefaultTask() {
                         .get()
                         .asSequence()
                         .flatMap { dir ->
+                            @Suppress("UseOrEmpty")
                             File(dir).listFiles { it.extension == "framework" }?.asSequence()
                                 ?: emptySequence()
                         }.firstOrNull {


### PR DESCRIPTION
## Summary
exportedManifestTask was wired to depend on each target's definitionTask inside the per-target loop, causing all targets (e.g. IosArm64) to be compiled even when only a single target (e.g. IosSimulatorArm64) was requested
- Moved the dependency to manifestTask once, outside the loop — exportedManifestTask only needs the manifest, not the compiled output of every target
- Removed the isFirstTarget parameter from CompileSwiftPackageTask along with the shared scratch-dir entries that were gated on it
## Known issue: caching of shared scratch directories
The removed isFirstTarget block was declaring artifacts/, plugins/, registry/, and checkouts/ under packageScratchDir as @OutputDirectories on the first compile task. These directories are no longer tracked by any task, which means:
- Gradle won't detect stale content in them and may skip re-runs incorrectly
- Incremental builds could produce wrong results if those dirs change between builds
These dirs need to be tracked as outputs on a suitable task (e.g. the registry/manifest task, or a dedicated clean-scratch task) in a follow-up.